### PR TITLE
Fix specification consistency across documentation

### DIFF
--- a/docs/spec/control-plane.md
+++ b/docs/spec/control-plane.md
@@ -49,6 +49,17 @@ It complements:
   Each `ResourceBinding` is created for that key; its `status.outputs` provide the concrete values.
 - **Separation of concerns:** Plan carries **how to use** (projection rules), Binding carries **what to provide** (outputs).
 
+**Example: Image resolution flow:**
+```yaml
+# ResourceBinding.status.outputs (by Resolver)
+outputs:
+  image: "registry.example.com/myapp:v1.2.3"
+
+# WorkloadPlan.spec.projection (by Orchestrator)  
+projection:
+  imageFrom: { bindingKey: "build-tool", outputKey: "image" }
+```
+
 ## Error mapping (abstract reasons for `Workload.status`)
 - Binding in progress/failure → `BindingPending` / `BindingFailed`
 - Outputs missing/mismatched vs plan → `ProjectionError`

--- a/docs/spec/lifecycle.md
+++ b/docs/spec/lifecycle.md
@@ -118,10 +118,12 @@ The Orchestrator sets `BindingsReady=True` when:
 
 3. **Plan Validation**: Ensure plan completeness and consistency
 
-### WorkloadPlan Lifecycle
+### Runtime materialization lifecycle (internal)
+
+> These phases are tracked by **runtime-internal resources**; `WorkloadPlan` has **no** `.status`.
 
 ```
-WorkloadPlan Phase Transitions:
+Runtime (internal) Phase Transitions:
 Pending → Planning → Projected (success)
                    ↘ Failed (error)
 ```

--- a/docs/spec/validation.md
+++ b/docs/spec/validation.md
@@ -166,7 +166,7 @@ metadata:
     environment: "production"            # Required environment label
 ```
 
-**Runtime Class Restrictions:**
+**Runtime class Restrictions:**
 
 > Runtime class selection is governed by `PlatformPolicy` and must not appear in `Workload.spec`.
 


### PR DESCRIPTION
Resolve implementation-discovered issues and ensure consistency
between CRD, RBAC, and lifecycle specifications.

Add opaque JSON type guidance using apiextensions.k8s.io/v1.JSON
to prevent controller-gen instability with interface{}/any types.

Standardize ResourceBinding.status.outputs schema with image field
and normative CEL constraints ensuring at least one output is present.

Align RBAC permissions with design principles removing invalid
PlatformPolicy access for users and WorkloadPlan.status writes
for runtime controllers.

Clarify WorkloadPlan has no status and phases are tracked by
runtime-internal resources in lifecycle documentation.

Add Required/Optional summary tables and strengthen Single-writer
principle documentation with explicit boundaries.