### PR TITLE
Implement Score Orchestrator MVP

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -178,9 +178,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Setup signal handler and context
+	ctx := ctrl.SetupSignalHandler()
+
+	// Setup indexers
+	if err := controller.SetupIndexers(ctx, mgr); err != nil {
+		setupLog.Error(err, "unable to set up indexers")
+		os.Exit(1)
+	}
+
 	if err := (&controller.WorkloadReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("workload-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Workload")
 		os.Exit(1)
@@ -197,7 +207,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,9 +5,27 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - score.dev
   resources:
+  - platformpolicies
+  - resourcebindings/status
   - workloads
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - score.dev
+  resources:
+  - resourcebindings
+  - workloadplans
   verbs:
   - create
   - delete

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Condition Types
+const (
+	ConditionReady         = "Ready"
+	ConditionBindingsReady = "BindingsReady"
+	ConditionRuntimeReady  = "RuntimeReady"
+	ConditionInputsValid   = "InputsValid"
+)
+
+// Reasons (abstract vocabulary - platform-agnostic)
+const (
+	ReasonSucceeded           = "Succeeded"
+	ReasonSpecInvalid         = "SpecInvalid"
+	ReasonPolicyViolation     = "PolicyViolation"
+	ReasonBindingPending      = "BindingPending"
+	ReasonBindingFailed       = "BindingFailed"
+	ReasonProjectionError     = "ProjectionError"
+	ReasonRuntimeSelecting    = "RuntimeSelecting"
+	ReasonRuntimeProvisioning = "RuntimeProvisioning"
+	ReasonRuntimeDegraded     = "RuntimeDegraded"
+	ReasonQuotaExceeded       = "QuotaExceeded"
+	ReasonPermissionDenied    = "PermissionDenied"
+	ReasonNetworkUnavailable  = "NetworkUnavailable"
+)
+
+// Standard condition messages (platform-agnostic)
+const (
+	MessageSpecValidationFailed      = "Workload specification validation failed"
+	MessageSpecValidationPending     = "Workload specification validation pending"
+	MessageBindingsNotReady          = "Resource bindings are not ready"
+	MessageBindingsProvisioning      = "Resource bindings are being provisioned"
+	MessageRuntimeProvisioningFailed = "Runtime provisioning failed"
+	MessageRuntimeProvisioning       = "Runtime is being provisioned"
+	MessageWorkloadReady             = "Workload is ready and operational"
+	MessageAllBindingsReady          = "All resource bindings are ready"
+	MessageBindingsFailed            = "One or more resource bindings have failed"
+	MessageNoBindingsFound           = "No resource bindings found"
+)
+
+// SetCondition updates a condition in the conditions slice
+func SetCondition(conditions *[]metav1.Condition, conditionType string, status metav1.ConditionStatus, reason string, message string) {
+	now := metav1.NewTime(time.Now())
+
+	for i, condition := range *conditions {
+		if condition.Type == conditionType {
+			// Update existing condition
+			if condition.Status != status || condition.Reason != reason {
+				(*conditions)[i].Status = status
+				(*conditions)[i].Reason = reason
+				(*conditions)[i].Message = message
+				(*conditions)[i].LastTransitionTime = now
+			} else if condition.Message != message {
+				// Update message only without changing transition time
+				(*conditions)[i].Message = message
+			}
+			return
+		}
+	}
+
+	// Add new condition
+	*conditions = append(*conditions, metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		LastTransitionTime: now,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+// IsConditionTrue returns true if the condition is present and set to True
+func IsConditionTrue(conditions []metav1.Condition, conditionType string) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// GetCondition returns the condition with the given type, or nil if not found
+func GetCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i, condition := range conditions {
+		if condition.Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// ComputeReadyCondition determines the Ready condition based on other conditions
+// Ready = InputsValid ∧ BindingsReady ∧ RuntimeReady
+func ComputeReadyCondition(conditions []metav1.Condition) (metav1.ConditionStatus, string, string) {
+	inputsValid := IsConditionTrue(conditions, ConditionInputsValid)
+	bindingsReady := IsConditionTrue(conditions, ConditionBindingsReady)
+	runtimeReady := IsConditionTrue(conditions, ConditionRuntimeReady)
+
+	if !inputsValid {
+		inputsCond := GetCondition(conditions, ConditionInputsValid)
+		if inputsCond != nil && inputsCond.Status == metav1.ConditionFalse {
+			return metav1.ConditionFalse, inputsCond.Reason, MessageSpecValidationFailed
+		}
+		return metav1.ConditionFalse, ReasonSpecInvalid, MessageSpecValidationPending
+	}
+
+	if !bindingsReady {
+		bindingsCond := GetCondition(conditions, ConditionBindingsReady)
+		if bindingsCond != nil && bindingsCond.Status == metav1.ConditionFalse {
+			return metav1.ConditionFalse, bindingsCond.Reason, MessageBindingsNotReady
+		}
+		return metav1.ConditionFalse, ReasonBindingPending, MessageBindingsProvisioning
+	}
+
+	if !runtimeReady {
+		runtimeCond := GetCondition(conditions, ConditionRuntimeReady)
+		if runtimeCond != nil && runtimeCond.Status == metav1.ConditionFalse {
+			return metav1.ConditionFalse, runtimeCond.Reason, MessageRuntimeProvisioningFailed
+		}
+		return metav1.ConditionFalse, ReasonRuntimeProvisioning, MessageRuntimeProvisioning
+	}
+
+	return metav1.ConditionTrue, ReasonSucceeded, MessageWorkloadReady
+}

--- a/internal/controller/indexers.go
+++ b/internal/controller/indexers.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/meta"
+)
+
+// SetupIndexers sets up the indexers for efficient lookups
+func SetupIndexers(ctx context.Context, mgr manager.Manager) error {
+	// Index ResourceBinding by workloadRef
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &scorev1b1.ResourceBinding{}, meta.IndexResourceBindingByWorkload,
+		func(obj client.Object) []string {
+			binding := obj.(*scorev1b1.ResourceBinding)
+			return []string{binding.Spec.WorkloadRef.Namespace + "/" + binding.Spec.WorkloadRef.Name}
+		},
+	); err != nil {
+		return err
+	}
+
+	// Index WorkloadPlan by workloadRef
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &scorev1b1.WorkloadPlan{}, meta.IndexWorkloadPlanByWorkload,
+		func(obj client.Object) []string {
+			plan := obj.(*scorev1b1.WorkloadPlan)
+			return []string{plan.Spec.WorkloadRef.Namespace + "/" + plan.Spec.WorkloadRef.Name}
+		},
+	); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,6 +56,10 @@ func TestControllers(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	// Set global Eventually timeouts for test stability
+	SetDefaultEventuallyTimeout(10 * time.Second)
+	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/internal/controller/watches.go
+++ b/internal/controller/watches.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/meta"
+)
+
+// EnqueueRequestForOwningWorkload returns a handler that enqueues the owner Workload
+// for ResourceBinding and WorkloadPlan changes
+func EnqueueRequestForOwningWorkload() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		// Try ResourceBinding first
+		if binding, ok := obj.(*scorev1b1.ResourceBinding); ok {
+			return []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      binding.Spec.WorkloadRef.Name,
+						Namespace: binding.Spec.WorkloadRef.Namespace,
+					},
+				},
+			}
+		}
+
+		// Try WorkloadPlan next
+		if plan, ok := obj.(*scorev1b1.WorkloadPlan); ok {
+			return []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      plan.Spec.WorkloadRef.Name,
+						Namespace: plan.Spec.WorkloadRef.Namespace,
+					},
+				},
+			}
+		}
+
+		// Unknown type - should not happen if used correctly
+		return []reconcile.Request{}
+	})
+}
+
+// GetResourceBindingsForWorkload retrieves all ResourceBindings for a given Workload
+func GetResourceBindingsForWorkload(ctx context.Context, c client.Client, workload *scorev1b1.Workload) ([]scorev1b1.ResourceBinding, error) {
+	bindingList := &scorev1b1.ResourceBindingList{}
+	key := fmt.Sprintf("%s/%s", workload.Namespace, workload.Name)
+
+	// Try using indexer first, fallback to label selector for tests
+	err := c.List(ctx, bindingList, client.MatchingFields{meta.IndexResourceBindingByWorkload: key})
+	if err != nil && err.Error() == "field label not supported: resourcebinding.workloadRef" {
+		// Fallback: use label selector when indexer is not available (e.g., in tests)
+		return getResourceBindingsWithoutIndex(ctx, c, workload)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return bindingList.Items, nil
+}
+
+// getResourceBindingsWithoutIndex retrieves ResourceBindings using owner reference or labels
+func getResourceBindingsWithoutIndex(ctx context.Context, c client.Client, workload *scorev1b1.Workload) ([]scorev1b1.ResourceBinding, error) {
+	bindingList := &scorev1b1.ResourceBindingList{}
+
+	// Use label selector to find bindings for this workload
+	err := c.List(ctx, bindingList,
+		client.InNamespace(workload.Namespace),
+		client.MatchingLabels{"score.dev/workload": workload.Name})
+	if err != nil {
+		return nil, err
+	}
+
+	return bindingList.Items, nil
+}
+
+// GetWorkloadPlanForWorkload retrieves the WorkloadPlan for a given Workload
+func GetWorkloadPlanForWorkload(ctx context.Context, c client.Client, workload *scorev1b1.Workload) (*scorev1b1.WorkloadPlan, error) {
+	planList := &scorev1b1.WorkloadPlanList{}
+	key := fmt.Sprintf("%s/%s", workload.Namespace, workload.Name)
+
+	// Try using indexer first, fallback to label selector for tests
+	err := c.List(ctx, planList, client.MatchingFields{meta.IndexWorkloadPlanByWorkload: key})
+	if err != nil && err.Error() == "field label not supported: workloadplan.workloadRef" {
+		// Fallback: use label selector when indexer is not available (e.g., in tests)
+		err = c.List(ctx, planList,
+			client.InNamespace(workload.Namespace),
+			client.MatchingLabels{"score.dev/workload": workload.Name})
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if len(planList.Items) == 0 {
+		return nil, nil // Not found
+	}
+
+	if len(planList.Items) > 1 {
+		return nil, fmt.Errorf("multiple WorkloadPlans found for Workload %s/%s", workload.Namespace, workload.Name)
+	}
+
+	return &planList.Items[0], nil
+}

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -18,46 +18,266 @@ package controller
 
 import (
 	"context"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/conditions"
+	"github.com/cappyzawa/score-orchestrator/internal/endpoint"
+	"github.com/cappyzawa/score-orchestrator/internal/meta"
+	"github.com/cappyzawa/score-orchestrator/internal/reconcile"
+	"github.com/cappyzawa/score-orchestrator/internal/status"
 )
 
 // WorkloadReconciler reconciles a Workload object
 type WorkloadReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
-// +kubebuilder:rbac:groups=score.dev,resources=workloads,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=score.dev,resources=workloads,verbs=get;list;watch
 // +kubebuilder:rbac:groups=score.dev,resources=workloads/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=score.dev,resources=workloads/finalizers,verbs=update
+// +kubebuilder:rbac:groups=score.dev,resources=resourcebindings;workloadplans,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=score.dev,resources=resourcebindings/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=score.dev,resources=platformpolicies,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Workload object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/reconcile
+// Reconcile handles Workload reconciliation - the single writer of Workload.status
 func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = logf.FromContext(ctx)
+	log := ctrl.LoggerFrom(ctx).WithValues("workload", req.NamespacedName)
 
-	// TODO(user): your logic here
+	// Get the Workload
+	workload := &scorev1b1.Workload{}
+	if err := r.Get(ctx, req.NamespacedName, workload); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Workload not found, assuming deleted")
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "Failed to get Workload")
+		return ctrl.Result{}, err
+	}
 
+	// Handle deletion
+	if !workload.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, workload)
+	}
+
+	// Ensure finalizer
+	if err := reconcile.EnsureFinalizer(ctx, r.Client, workload); err != nil {
+		log.Error(err, "Failed to ensure finalizer")
+		return ctrl.Result{}, err
+	}
+
+	// Validate inputs and apply policy
+	inputsValid, reason, message := r.validateInputsAndPolicy(ctx, workload)
+	conditions.SetCondition(&workload.Status.Conditions,
+		conditions.ConditionInputsValid,
+		inputsValidToConditionStatus(inputsValid),
+		reason, message)
+
+	if !inputsValid {
+		return r.updateStatusAndReturn(ctx, workload, ctrl.Result{}, nil)
+	}
+
+	// Create/update ResourceBindings
+	if err := reconcile.UpsertResourceBindings(ctx, r.Client, workload); err != nil {
+		log.Error(err, "Failed to upsert ResourceBindings")
+		r.Recorder.Eventf(workload, "Warning", "BindingError", "Failed to create resource bindings: %v", err)
+		return ctrl.Result{}, err
+	}
+
+	// Aggregate binding statuses
+	bindings, err := GetResourceBindingsForWorkload(ctx, r.Client, workload)
+	if err != nil {
+		log.Error(err, "Failed to get ResourceBindings")
+		return ctrl.Result{}, err
+	}
+
+	agg := status.AggregateBindingStatuses(bindings)
+	status.UpdateWorkloadStatusFromAggregation(workload, agg)
+
+	// Create WorkloadPlan if bindings are ready
+	if agg.Ready {
+		runtimeClass := r.determineRuntimeClass(ctx, workload)
+		if err := reconcile.UpsertWorkloadPlan(ctx, r.Client, workload, bindings, runtimeClass); err != nil {
+			log.Error(err, "Failed to upsert WorkloadPlan")
+			r.Recorder.Eventf(workload, "Warning", "PlanError", "Failed to create workload plan: %v", err)
+			return ctrl.Result{}, err
+		}
+		r.Recorder.Eventf(workload, "Normal", "PlanCreated", "WorkloadPlan created successfully")
+	}
+
+	// Update RuntimeReady and endpoint (MVP logic)
+	r.updateRuntimeStatus(ctx, workload)
+
+	// Compute and set Ready condition
+	readyStatus, readyReason, readyMessage := conditions.ComputeReadyCondition(workload.Status.Conditions)
+	conditions.SetCondition(&workload.Status.Conditions, conditions.ConditionReady, readyStatus, readyReason, readyMessage)
+
+	if readyStatus == metav1.ConditionTrue {
+		r.Recorder.Event(workload, "Normal", "Ready", "Workload is ready and operational")
+	}
+
+	return r.updateStatusAndReturn(ctx, workload, ctrl.Result{}, nil)
+}
+
+// handleDeletion handles Workload deletion with finalizer cleanup
+func (r *WorkloadReconciler) handleDeletion(ctx context.Context, workload *scorev1b1.Workload) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	if !reconcile.HasFinalizer(workload) {
+		return ctrl.Result{}, nil
+	}
+
+	// Wait for ResourceBindings to be cleaned up by their owners (Resolvers)
+	bindings, err := GetResourceBindingsForWorkload(ctx, r.Client, workload)
+	if err != nil {
+		log.Error(err, "Failed to get ResourceBindings during deletion")
+		return ctrl.Result{}, err
+	}
+
+	if len(bindings) > 0 {
+		log.Info("Waiting for ResourceBindings to be cleaned up", "count", len(bindings))
+		return ctrl.Result{RequeueAfter: 30 * 1000000000}, nil // 30 seconds
+	}
+
+	// Remove finalizer
+	if err := reconcile.RemoveFinalizer(ctx, r.Client, workload); err != nil {
+		log.Error(err, "Failed to remove finalizer")
+		return ctrl.Result{}, err
+	}
+
+	r.Recorder.Event(workload, "Normal", "Deleted", "Workload cleanup completed")
 	return ctrl.Result{}, nil
+}
+
+// validateInputsAndPolicy validates workload inputs and applies platform policy
+func (r *WorkloadReconciler) validateInputsAndPolicy(ctx context.Context, workload *scorev1b1.Workload) (bool, string, string) {
+	// For MVP: basic validation (CRD-level validation handles most cases)
+	if len(workload.Spec.Resources) == 0 {
+		return false, conditions.ReasonSpecInvalid, "Workload must define at least one resource"
+	}
+
+	// Policy application is minimal in MVP - just check if policy exists
+	policy := r.findApplicablePlatformPolicy(ctx, workload)
+	if policy == nil {
+		// No policy is OK for MVP - use defaults
+		return true, conditions.ReasonSucceeded, "Workload specification is valid"
+	}
+
+	// In a full implementation, this would validate against policy constraints
+	return true, conditions.ReasonSucceeded, "Workload specification is valid and policy compliant"
+}
+
+// findApplicablePlatformPolicy finds the applicable PlatformPolicy for the workload
+func (r *WorkloadReconciler) findApplicablePlatformPolicy(ctx context.Context, _ *scorev1b1.Workload) *scorev1b1.PlatformPolicy {
+	policyList := &scorev1b1.PlatformPolicyList{}
+	if err := r.List(ctx, policyList); err != nil {
+		return nil
+	}
+
+	// For MVP: simple first-match logic
+	// Real implementation would have sophisticated targeting logic
+	for _, policy := range policyList.Items {
+		if policy.Spec.Targeting == nil {
+			// Policy applies to all workloads
+			return &policy
+		}
+		// For MVP, we skip complex targeting logic
+	}
+
+	return nil
+}
+
+// determineRuntimeClass determines the runtime class for the workload
+func (r *WorkloadReconciler) determineRuntimeClass(ctx context.Context, workload *scorev1b1.Workload) string {
+	policy := r.findApplicablePlatformPolicy(ctx, workload)
+	if policy != nil && policy.Spec.RuntimeClass != "" {
+		return policy.Spec.RuntimeClass
+	}
+
+	// Default runtime class for MVP
+	return meta.RuntimeClassKubernetes
+}
+
+// updateRuntimeStatus updates RuntimeReady condition and endpoint (MVP implementation)
+func (r *WorkloadReconciler) updateRuntimeStatus(ctx context.Context, workload *scorev1b1.Workload) {
+	policy := r.findApplicablePlatformPolicy(ctx, workload)
+
+	// MVP logic: If PlatformPolicy has endpoint template, we can determine success
+	if policy != nil && policy.Spec.EndpointPolicy != nil && policy.Spec.EndpointPolicy.Template != nil {
+		// Derive endpoint from template
+		derivedEndpoint := endpoint.DeriveEndpoint(workload, policy)
+		if derivedEndpoint != nil {
+			workload.Status.Endpoint = derivedEndpoint
+			conditions.SetCondition(&workload.Status.Conditions,
+				conditions.ConditionRuntimeReady,
+				metav1.ConditionTrue,
+				conditions.ReasonSucceeded,
+				"Runtime provisioned successfully with endpoint")
+			return
+		}
+	}
+
+	// Check if we have a WorkloadPlan (indicates runtime is being engaged)
+	plan, err := GetWorkloadPlanForWorkload(ctx, r.Client, workload)
+	if err != nil || plan == nil {
+		conditions.SetCondition(&workload.Status.Conditions,
+			conditions.ConditionRuntimeReady,
+			metav1.ConditionFalse,
+			conditions.ReasonRuntimeSelecting,
+			"Runtime controller is being selected")
+		return
+	}
+
+	// Plan exists, runtime is provisioning
+	conditions.SetCondition(&workload.Status.Conditions,
+		conditions.ConditionRuntimeReady,
+		metav1.ConditionFalse,
+		conditions.ReasonRuntimeProvisioning,
+		"Runtime is provisioning workload")
+}
+
+// updateStatusAndReturn updates the Workload status and returns the result
+func (r *WorkloadReconciler) updateStatusAndReturn(ctx context.Context, workload *scorev1b1.Workload, result ctrl.Result, originalErr error) (ctrl.Result, error) {
+	if err := r.Status().Update(ctx, workload); err != nil {
+		if apierrors.IsConflict(err) {
+			// Resource version conflict - requeue for retry
+			ctrl.LoggerFrom(ctx).V(1).Info("Resource version conflict, requeuing", "error", err)
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
+		ctrl.LoggerFrom(ctx).Error(err, "Failed to update Workload status")
+		return ctrl.Result{}, err
+	}
+	return result, originalErr
+}
+
+// inputsValidToConditionStatus converts boolean to ConditionStatus
+func inputsValidToConditionStatus(valid bool) metav1.ConditionStatus {
+	if valid {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&scorev1b1.Workload{}).
+		Owns(&scorev1b1.ResourceBinding{}).
+		Owns(&scorev1b1.WorkloadPlan{}).
+		Watches(&scorev1b1.ResourceBinding{}, EnqueueRequestForOwningWorkload()).
+		Watches(&scorev1b1.WorkloadPlan{}, EnqueueRequestForOwningWorkload()).
 		Named("workload").
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }

--- a/internal/controller/workload_controller_test.go
+++ b/internal/controller/workload_controller_test.go
@@ -18,73 +18,268 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/conditions"
+	"github.com/cappyzawa/score-orchestrator/internal/meta"
+	internalreconcile "github.com/cappyzawa/score-orchestrator/internal/reconcile"
 )
+
+// Helper function to create string pointer
+func stringPtr(s string) *string {
+	return &s
+}
+
+// Index functions for ResourceBinding and WorkloadPlan lookups (matching indexers.go)
+func indexResourceBindingByWorkload(obj client.Object) []string {
+	binding := obj.(*scorev1b1.ResourceBinding)
+	return []string{binding.Spec.WorkloadRef.Namespace + "/" + binding.Spec.WorkloadRef.Name}
+}
+
+func indexWorkloadPlanByWorkload(obj client.Object) []string {
+	plan := obj.(*scorev1b1.WorkloadPlan)
+	return []string{plan.Spec.WorkloadRef.Namespace + "/" + plan.Spec.WorkloadRef.Name}
+}
 
 var _ = Describe("Workload Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		workload := &scorev1b1.Workload{}
+		var (
+			testNS             *corev1.Namespace
+			cancel             context.CancelFunc
+			doneCh             chan struct{}
+			mgr                manager.Manager
+			k8sCl              client.Client
+			workload           *scorev1b1.Workload
+			typeNamespacedName types.NamespacedName
+		)
 
 		BeforeEach(func() {
-			By("creating the custom resource for the Kind Workload")
-			err := k8sClient.Get(ctx, typeNamespacedName, workload)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &scorev1b1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
+			// 1) Create temporary namespace with unique name
+			testNS = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), testNS)).To(Succeed())
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), client.ObjectKey{Name: testNS.Name}, &corev1.Namespace{})
+			}).Should(Succeed())
+
+			// 2) Create Manager with NS-scoped cache and port conflict avoidance
+			mgrCtx, c := context.WithCancel(context.Background())
+			cancel = c
+			doneCh = make(chan struct{})
+
+			var err error
+			mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+				Scheme: k8sClient.Scheme(),
+				// Cache scoped to this test's namespace only
+				Cache: cache.Options{
+					DefaultNamespaces: map[string]cache.Config{
+						testNS.Name: {},
 					},
-					Spec: scorev1b1.WorkloadSpec{
-						Containers: map[string]scorev1b1.ContainerSpec{
-							"app": {
-								Image: "nginx:latest",
-							},
+				},
+				Metrics: server.Options{
+					BindAddress: "0", // Disable metrics server
+				},
+				HealthProbeBindAddress: "0", // Disable health probe
+				LeaderElection:         false,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// 3) Setup indexers before starting manager
+			fi := mgr.GetFieldIndexer()
+			Expect(fi.IndexField(mgrCtx, &scorev1b1.ResourceBinding{}, meta.IndexResourceBindingByWorkload, indexResourceBindingByWorkload)).To(Succeed())
+			Expect(fi.IndexField(mgrCtx, &scorev1b1.WorkloadPlan{}, meta.IndexWorkloadPlanByWorkload, indexWorkloadPlanByWorkload)).To(Succeed())
+
+			// 4) Setup WorkloadReconciler with unique name for this test
+			reconciler := &WorkloadReconciler{
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("workload-controller-test-" + testNS.Name),
+			}
+			// Setup controller directly with unique name to avoid conflicts between tests
+			err = ctrl.NewControllerManagedBy(mgr).
+				For(&scorev1b1.Workload{}).
+				Owns(&scorev1b1.ResourceBinding{}).
+				Owns(&scorev1b1.WorkloadPlan{}).
+				Watches(&scorev1b1.ResourceBinding{}, EnqueueRequestForOwningWorkload()).
+				Watches(&scorev1b1.WorkloadPlan{}, EnqueueRequestForOwningWorkload()).
+				Named("workload-" + testNS.Name). // Unique name per test namespace
+				Complete(reconciler)
+			Expect(err).NotTo(HaveOccurred())
+
+			// 5) Start manager and wait for cache sync
+			go func() {
+				defer close(doneCh)
+				defer GinkgoRecover()
+				Expect(mgr.Start(mgrCtx)).To(Succeed())
+			}()
+			// Critical: wait for cache sync before proceeding
+			Expect(mgr.GetCache().WaitForCacheSync(mgrCtx)).To(BeTrue())
+
+			k8sCl = mgr.GetClient()
+
+			// 6) Create test workload with GenerateName
+			workload = &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-workload-",
+					Namespace:    testNS.Name,
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Image: "nginx:latest",
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+					Resources: map[string]scorev1b1.ResourceSpec{
+						"db": {
+							Type: "postgresql",
+						},
+					},
+				},
+			}
+			Expect(k8sCl.Create(context.Background(), workload)).To(Succeed())
+
+			// Set the typeNamespacedName after creation (since GenerateName assigns the actual name)
+			typeNamespacedName = types.NamespacedName{
+				Name:      workload.Name,
+				Namespace: workload.Namespace,
 			}
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &scorev1b1.Workload{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
+			// 1) Clean shutdown: Delete namespace with Foreground propagation and wait for completion
+			By("Deleting test namespace with Foreground propagation")
+			policy := metav1.DeletePropagationForeground
+			Expect(k8sClient.Delete(context.Background(), testNS, &client.DeleteOptions{PropagationPolicy: &policy})).To(Succeed())
+			Eventually(func() error {
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: testNS.Name}, &corev1.Namespace{})
+				if err != nil && apierrors.IsNotFound(err) {
+					return nil // Successfully deleted
+				}
+				return err
+			}, 20*time.Second, 500*time.Millisecond).Should(Succeed())
 
-			By("Cleanup the specific resource instance Workload")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			// 2) Stop manager gracefully: cancel context then wait for goroutine completion
+			By("Stopping manager gracefully")
+			cancel()
+			Eventually(func() bool {
+				select {
+				case <-doneCh:
+					return true
+				default:
+					return false
+				}
+			}, 5*time.Second, 50*time.Millisecond).Should(BeTrue())
 		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &WorkloadReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+		It("should successfully reconcile and create ResourceBindings", func() {
+			By("Waiting for controller to process the workload creation via Watch")
+			Eventually(func(g Gomega) {
+				var updatedWorkload scorev1b1.Workload
+				g.Expect(k8sCl.Get(context.Background(), typeNamespacedName, &updatedWorkload)).To(Succeed())
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+				By("Checking that finalizer was added")
+				g.Expect(internalreconcile.HasFinalizer(&updatedWorkload)).To(BeTrue())
+
+				By("Checking that InputsValid condition was set")
+				inputsCondition := conditions.GetCondition(updatedWorkload.Status.Conditions, conditions.ConditionInputsValid)
+				g.Expect(inputsCondition).NotTo(BeNil())
+				g.Expect(inputsCondition.Status).To(Equal(metav1.ConditionTrue))
+			}).Should(Succeed())
+
+			By("Checking that ResourceBinding was created via Watch")
+			Eventually(func(g Gomega) {
+				bindingList := &scorev1b1.ResourceBindingList{}
+				g.Expect(k8sCl.List(context.Background(), bindingList, client.InNamespace(testNS.Name))).To(Succeed())
+				g.Expect(bindingList.Items).ToNot(BeEmpty())
+
+				binding := bindingList.Items[0]
+				g.Expect(binding.Spec.Key).To(Equal("db"))
+				g.Expect(binding.Spec.Type).To(Equal("postgresql"))
+				g.Expect(binding.Spec.WorkloadRef.Name).To(Equal(workload.Name))
+				g.Expect(binding.Spec.WorkloadRef.Namespace).To(Equal(workload.Namespace))
+			}).Should(Succeed())
+
+			By("Checking that BindingsReady condition is False initially")
+			Eventually(func(g Gomega) {
+				var updatedWorkload scorev1b1.Workload
+				g.Expect(k8sCl.Get(context.Background(), typeNamespacedName, &updatedWorkload)).To(Succeed())
+				bindingsCondition := conditions.GetCondition(updatedWorkload.Status.Conditions, conditions.ConditionBindingsReady)
+				g.Expect(bindingsCondition).NotTo(BeNil())
+				g.Expect(bindingsCondition.Status).To(Equal(metav1.ConditionFalse))
+			}).Should(Succeed())
+		})
+
+		It("should create WorkloadPlan when bindings are ready", func() {
+			// Wait for ResourceBinding to be created (event-driven)
+			By("Waiting for ResourceBinding to be created via Watch")
+			var bindingKey types.NamespacedName
+			Eventually(func(g Gomega) {
+				bindingList := &scorev1b1.ResourceBindingList{}
+				g.Expect(k8sCl.List(context.Background(), bindingList, client.InNamespace(testNS.Name))).To(Succeed())
+				g.Expect(bindingList.Items).ToNot(BeEmpty())
+				bindingKey = types.NamespacedName{
+					Name:      bindingList.Items[0].Name,
+					Namespace: bindingList.Items[0].Namespace,
+				}
+			}).Should(Succeed())
+
+			By("Updating ResourceBinding status to Bound")
+			binding := &scorev1b1.ResourceBinding{}
+			Expect(k8sClient.Get(context.Background(), bindingKey, binding)).To(Succeed())
+
+			binding.Status.Phase = scorev1b1.ResourceBindingPhaseBound
+			binding.Status.OutputsAvailable = true
+			binding.Status.Reason = conditions.ReasonSucceeded
+			binding.Status.Message = "Resource provisioned successfully"
+			binding.Status.Outputs = scorev1b1.ResourceBindingOutputs{
+				URI: stringPtr("postgresql://user:pass@localhost:5432/db"),
+			}
+			Expect(k8sClient.Status().Update(context.Background(), binding)).To(Succeed())
+
+			By("Waiting for binding status change to propagate to cached client")
+			Eventually(func(g Gomega) {
+				var updatedBinding scorev1b1.ResourceBinding
+				g.Expect(k8sCl.Get(context.Background(), bindingKey, &updatedBinding)).To(Succeed())
+				g.Expect(updatedBinding.Status.Phase).To(Equal(scorev1b1.ResourceBindingPhaseBound))
+				g.Expect(updatedBinding.Status.OutputsAvailable).To(BeTrue())
+			}).Should(Succeed())
+
+			By("Waiting for BindingsReady condition to become True via Watch")
+			Eventually(func(g Gomega) {
+				var updatedWorkload scorev1b1.Workload
+				g.Expect(k8sCl.Get(context.Background(), typeNamespacedName, &updatedWorkload)).To(Succeed())
+				bindingsCondition := conditions.GetCondition(updatedWorkload.Status.Conditions, conditions.ConditionBindingsReady)
+				g.Expect(bindingsCondition).NotTo(BeNil())
+				g.Expect(bindingsCondition.Status).To(Equal(metav1.ConditionTrue))
+			}).Should(Succeed())
+
+			By("Waiting for WorkloadPlan to be created via Watch")
+			planKey := types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}
+			Eventually(func() error {
+				var plan scorev1b1.WorkloadPlan
+				return k8sCl.Get(context.Background(), planKey, &plan)
+			}).Should(Succeed())
+
+			By("Verifying WorkloadPlan content")
+			var finalPlan scorev1b1.WorkloadPlan
+			Expect(k8sCl.Get(context.Background(), planKey, &finalPlan)).To(Succeed())
+			Expect(finalPlan.Spec.WorkloadRef.Name).To(Equal(workload.Name))
+			Expect(finalPlan.Spec.RuntimeClass).To(Equal(meta.RuntimeClassKubernetes))
 		})
 	})
 })

--- a/internal/endpoint/derive.go
+++ b/internal/endpoint/derive.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+)
+
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
+// DeriveEndpoint determines the canonical endpoint for a Workload
+// MVP implementation: Only supports PlatformPolicy template-based derivation
+func DeriveEndpoint(workload *scorev1b1.Workload, policy *scorev1b1.PlatformPolicy) *string {
+	if policy == nil || policy.Spec.EndpointPolicy == nil || policy.Spec.EndpointPolicy.Template == nil {
+		return nil // No template available - requires runtime reporting (future phase)
+	}
+
+	template := *policy.Spec.EndpointPolicy.Template
+	endpoint := renderTemplate(template, workload)
+
+	if endpoint == "" {
+		return nil
+	}
+
+	// Normalize the endpoint
+	normalized := normalizeEndpoint(endpoint, policy.Spec.EndpointPolicy.PreferHTTPS)
+	return &normalized
+}
+
+// renderTemplate performs basic template rendering for MVP
+// Template variables supported: {{.Name}}, {{.Namespace}}
+func renderTemplate(template string, workload *scorev1b1.Workload) string {
+	result := template
+	result = strings.ReplaceAll(result, "{{.Name}}", workload.Name)
+	result = strings.ReplaceAll(result, "{{.Namespace}}", workload.Namespace)
+
+	// Additional template variables can be added here
+	// For MVP, we only support basic workload metadata
+
+	return result
+}
+
+// normalizeEndpoint applies normalization rules to the endpoint
+func normalizeEndpoint(endpoint string, preferHTTPS *bool) string {
+	// Parse the URL
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return endpoint // Return as-is if parsing fails
+	}
+
+	// Apply HTTPS preference if specified
+	if preferHTTPS != nil && *preferHTTPS {
+		if u.Scheme == schemeHTTP {
+			u.Scheme = schemeHTTPS
+		}
+	}
+
+	// Normalize port handling
+	u = normalizePort(u)
+
+	// Ensure FQDN if hostname doesn't contain dots (add cluster domain)
+	if u.Host != "" && !strings.Contains(u.Hostname(), ".") {
+		// For MVP, we assume cluster.local domain
+		// Real implementation would get this from platform configuration
+		u.Host = fmt.Sprintf("%s.%s.svc.cluster.local", u.Host, "default")
+		if u.Port() != "" {
+			u.Host = fmt.Sprintf("%s:%s", u.Host, u.Port())
+		}
+	}
+
+	return u.String()
+}
+
+// normalizePort removes standard ports and handles non-standard ones
+func normalizePort(u *url.URL) *url.URL {
+	port := u.Port()
+	if port == "" {
+		return u
+	}
+
+	// Remove standard ports
+	if (u.Scheme == schemeHTTP && port == "80") || (u.Scheme == schemeHTTPS && port == "443") {
+		hostname := u.Hostname()
+		u.Host = hostname
+	}
+
+	return u
+}
+
+// GetServiceBasedEndpoint derives endpoint from service configuration (future implementation)
+// MVP: This is a placeholder for when service-based derivation is implemented
+func GetServiceBasedEndpoint(workload *scorev1b1.Workload) *string {
+	// Future implementation:
+	// 1. Look for named ports (web, http, https, main)
+	// 2. Handle single port case
+	// 3. Apply platform-specific ingress patterns
+
+	if workload.Spec.Service == nil || len(workload.Spec.Service.Ports) == 0 {
+		return nil
+	}
+
+	// For MVP, return nil to indicate service-based derivation is not implemented
+	// This will rely on PlatformPolicy templates or runtime reporting
+	return nil
+}
+
+// ValidateEndpoint checks if the endpoint is a valid URI
+func ValidateEndpoint(endpoint string) error {
+	if endpoint == "" {
+		return fmt.Errorf("endpoint cannot be empty")
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid URL format: %w", err)
+	}
+
+	if u.Scheme == "" {
+		return fmt.Errorf("endpoint must include scheme (http/https)")
+	}
+
+	if u.Scheme != schemeHTTP && u.Scheme != schemeHTTPS {
+		return fmt.Errorf("endpoint scheme must be http or https, got: %s", u.Scheme)
+	}
+
+	if u.Host == "" {
+		return fmt.Errorf("endpoint must include host")
+	}
+
+	// Validate port if present
+	if port := u.Port(); port != "" {
+		if portNum, err := strconv.Atoi(port); err != nil || portNum < 1 || portNum > 65535 {
+			return fmt.Errorf("invalid port number: %s", port)
+		}
+	}
+
+	return nil
+}
+
+// IsHTTPS returns true if the endpoint uses HTTPS
+func IsHTTPS(endpoint string) bool {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == schemeHTTPS
+}
+
+// ExtractHostPort returns the host and port from an endpoint
+func ExtractHostPort(endpoint string) (string, string, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", "", err
+	}
+
+	hostname := u.Hostname()
+	port := u.Port()
+
+	// Use default ports if not specified
+	if port == "" {
+		switch u.Scheme {
+		case schemeHTTP:
+			port = "80"
+		case schemeHTTPS:
+			port = "443"
+		}
+	}
+
+	return hostname, port, nil
+}

--- a/internal/meta/names.go
+++ b/internal/meta/names.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+// Finalizer names
+const (
+	WorkloadFinalizer = "workloads.score.dev/finalizer"
+)
+
+// Field indexer names
+const (
+	IndexResourceBindingByWorkload = "resourcebinding.workloadRef"
+	IndexWorkloadPlanByWorkload    = "workloadplan.workloadRef"
+)
+
+// Event reasons
+const (
+	EventBindingCreated = "BindingCreated"
+	EventPlanCreated    = "PlanCreated"
+	EventReady          = "Ready"
+)
+
+// Runtime classes
+const (
+	RuntimeClassKubernetes = "kubernetes"
+)

--- a/internal/reconcile/binding.go
+++ b/internal/reconcile/binding.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+)
+
+// UpsertResourceBindings creates or updates ResourceBinding resources for each resource in the Workload spec
+func UpsertResourceBindings(ctx context.Context, c client.Client, workload *scorev1b1.Workload) error {
+	for key, resource := range workload.Spec.Resources {
+		if err := upsertResourceBinding(ctx, c, workload, key, resource); err != nil {
+			return fmt.Errorf("failed to upsert ResourceBinding for key %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// upsertResourceBinding creates or updates a single ResourceBinding
+func upsertResourceBinding(ctx context.Context, c client.Client, workload *scorev1b1.Workload, key string, resource scorev1b1.ResourceSpec) error {
+	bindingName := fmt.Sprintf("%s-%s", workload.Name, key)
+	binding := &scorev1b1.ResourceBinding{}
+
+	// Try to get existing binding
+	err := c.Get(ctx, types.NamespacedName{
+		Name:      bindingName,
+		Namespace: workload.Namespace,
+	}, binding)
+
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get ResourceBinding %s: %w", bindingName, err)
+	}
+
+	// Prepare the desired spec
+	desiredSpec := scorev1b1.ResourceBindingSpec{
+		WorkloadRef: scorev1b1.NamespacedName{
+			Name:      workload.Name,
+			Namespace: workload.Namespace,
+		},
+		Key:  key,
+		Type: resource.Type,
+	}
+
+	// Set optional fields if present
+	if resource.Class != nil {
+		desiredSpec.Class = resource.Class
+	}
+	if resource.Params != nil {
+		desiredSpec.Params = resource.Params
+	}
+
+	if errors.IsNotFound(err) {
+		// Create new binding
+		binding = &scorev1b1.ResourceBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bindingName,
+				Namespace: workload.Namespace,
+				Labels: map[string]string{
+					"score.dev/workload": workload.Name,
+					"score.dev/key":      key,
+				},
+			},
+			Spec: desiredSpec,
+		}
+
+		// Set owner reference
+		if err := controllerutil.SetControllerReference(workload, binding, c.Scheme()); err != nil {
+			return fmt.Errorf("failed to set owner reference: %w", err)
+		}
+
+		if err := c.Create(ctx, binding); err != nil {
+			return fmt.Errorf("failed to create ResourceBinding: %w", err)
+		}
+	} else {
+		// Update existing binding if spec differs
+		if !resourceBindingSpecEqual(binding.Spec, desiredSpec) {
+			binding.Spec = desiredSpec
+			if err := c.Update(ctx, binding); err != nil {
+				return fmt.Errorf("failed to update ResourceBinding: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// resourceBindingSpecEqual compares two ResourceBindingSpec structs for equality
+func resourceBindingSpecEqual(a, b scorev1b1.ResourceBindingSpec) bool {
+	if a.WorkloadRef != b.WorkloadRef || a.Key != b.Key || a.Type != b.Type {
+		return false
+	}
+
+	// Compare optional string pointers
+	if (a.Class == nil) != (b.Class == nil) {
+		return false
+	}
+	if a.Class != nil && *a.Class != *b.Class {
+		return false
+	}
+
+	if (a.ID == nil) != (b.ID == nil) {
+		return false
+	}
+	if a.ID != nil && *a.ID != *b.ID {
+		return false
+	}
+
+	// For Params (JSON), we do a simple nil check
+	// More sophisticated comparison could be added if needed
+	if (a.Params == nil) != (b.Params == nil) {
+		return false
+	}
+
+	return true
+}

--- a/internal/reconcile/finalizer.go
+++ b/internal/reconcile/finalizer.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/meta"
+)
+
+// EnsureFinalizer adds the finalizer to the workload if it doesn't exist
+func EnsureFinalizer(ctx context.Context, c client.Client, workload *scorev1b1.Workload) error {
+	if controllerutil.ContainsFinalizer(workload, meta.WorkloadFinalizer) {
+		return nil
+	}
+
+	controllerutil.AddFinalizer(workload, meta.WorkloadFinalizer)
+	return c.Update(ctx, workload)
+}
+
+// RemoveFinalizer removes the finalizer from the workload
+func RemoveFinalizer(ctx context.Context, c client.Client, workload *scorev1b1.Workload) error {
+	if !controllerutil.ContainsFinalizer(workload, meta.WorkloadFinalizer) {
+		return nil
+	}
+
+	controllerutil.RemoveFinalizer(workload, meta.WorkloadFinalizer)
+	return c.Update(ctx, workload)
+}
+
+// HasFinalizer returns true if the workload has the finalizer
+func HasFinalizer(workload *scorev1b1.Workload) bool {
+	return controllerutil.ContainsFinalizer(workload, meta.WorkloadFinalizer)
+}

--- a/internal/reconcile/plan.go
+++ b/internal/reconcile/plan.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+)
+
+// UpsertWorkloadPlan creates or updates the WorkloadPlan for the given Workload
+func UpsertWorkloadPlan(ctx context.Context, c client.Client, workload *scorev1b1.Workload, bindings []scorev1b1.ResourceBinding, runtimeClass string) error {
+	planName := workload.Name // Same name as Workload
+	plan := &scorev1b1.WorkloadPlan{}
+
+	// Try to get existing plan
+	err := c.Get(ctx, types.NamespacedName{
+		Name:      planName,
+		Namespace: workload.Namespace,
+	}, plan)
+
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get WorkloadPlan %s: %w", planName, err)
+	}
+
+	// Build the desired spec
+	desiredSpec := scorev1b1.WorkloadPlanSpec{
+		WorkloadRef: scorev1b1.WorkloadPlanWorkloadRef{
+			Name:      workload.Name,
+			Namespace: workload.Namespace,
+		},
+		ObservedWorkloadGeneration: workload.Generation,
+		RuntimeClass:               runtimeClass,
+		Projection:                 buildProjection(workload, bindings),
+		Bindings:                   buildPlanBindings(bindings),
+	}
+
+	if errors.IsNotFound(err) {
+		// Create new plan
+		plan = &scorev1b1.WorkloadPlan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      planName,
+				Namespace: workload.Namespace,
+				Labels: map[string]string{
+					"score.dev/workload": workload.Name,
+				},
+			},
+			Spec: desiredSpec,
+		}
+
+		// Set owner reference
+		if err := controllerutil.SetControllerReference(workload, plan, c.Scheme()); err != nil {
+			return fmt.Errorf("failed to set owner reference: %w", err)
+		}
+
+		if err := c.Create(ctx, plan); err != nil {
+			if errors.IsAlreadyExists(err) {
+				// Plan already exists, try to get it and update if needed
+				existingPlan := &scorev1b1.WorkloadPlan{}
+				if getErr := c.Get(ctx, types.NamespacedName{
+					Name:      planName,
+					Namespace: workload.Namespace,
+				}, existingPlan); getErr != nil {
+					return fmt.Errorf("failed to get existing WorkloadPlan after create conflict: %w", getErr)
+				}
+				// Update existing plan if spec differs
+				if !workloadPlanSpecEqual(existingPlan.Spec, desiredSpec) {
+					existingPlan.Spec = desiredSpec
+					if updateErr := c.Update(ctx, existingPlan); updateErr != nil {
+						return fmt.Errorf("failed to update existing WorkloadPlan: %w", updateErr)
+					}
+				}
+				return nil
+			}
+			return fmt.Errorf("failed to create WorkloadPlan: %w", err)
+		}
+	} else {
+		// Update existing plan if spec differs
+		if !workloadPlanSpecEqual(plan.Spec, desiredSpec) {
+			plan.Spec = desiredSpec
+			if err := c.Update(ctx, plan); err != nil {
+				return fmt.Errorf("failed to update WorkloadPlan: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// buildProjection creates the projection rules for injecting binding outputs
+func buildProjection(_ *scorev1b1.Workload, bindings []scorev1b1.ResourceBinding) scorev1b1.WorkloadProjection {
+	projection := scorev1b1.WorkloadProjection{}
+
+	// Build environment variable mappings
+	// This is a simplified projection - real implementation would need more sophisticated logic
+	for _, binding := range bindings {
+		if binding.Status.OutputsAvailable {
+			// Create common environment variable mappings
+			// This is MVP implementation - more sophisticated mapping would be configurable
+			envVar := fmt.Sprintf("%s_URI", strings.ToUpper(binding.Spec.Key))
+			projection.Env = append(projection.Env, scorev1b1.EnvMapping{
+				Name: envVar,
+				From: scorev1b1.FromBindingOutput{
+					BindingKey: binding.Spec.Key,
+					OutputKey:  "uri", // Common output key
+				},
+			})
+		}
+	}
+
+	return projection
+}
+
+// buildPlanBindings creates the binding requirements for the runtime
+func buildPlanBindings(bindings []scorev1b1.ResourceBinding) []scorev1b1.PlanBinding {
+	planBindings := make([]scorev1b1.PlanBinding, 0, len(bindings))
+
+	for _, binding := range bindings {
+		planBinding := scorev1b1.PlanBinding{
+			Key:  binding.Spec.Key,
+			Type: binding.Spec.Type,
+		}
+
+		if binding.Spec.Class != nil {
+			planBinding.Class = binding.Spec.Class
+		}
+
+		planBindings = append(planBindings, planBinding)
+	}
+
+	return planBindings
+}
+
+// workloadPlanSpecEqual compares two WorkloadPlanSpec structs for equality
+func workloadPlanSpecEqual(a, b scorev1b1.WorkloadPlanSpec) bool {
+	// Simple comparison for MVP - could be more sophisticated
+	if a.WorkloadRef != b.WorkloadRef {
+		return false
+	}
+	if a.ObservedWorkloadGeneration != b.ObservedWorkloadGeneration {
+		return false
+	}
+	if a.RuntimeClass != b.RuntimeClass {
+		return false
+	}
+
+	// For MVP, we do a simple length check for slices
+	// More sophisticated comparison could be added if needed
+	if len(a.Projection.Env) != len(b.Projection.Env) {
+		return false
+	}
+	if len(a.Bindings) != len(b.Bindings) {
+		return false
+	}
+
+	return true
+}

--- a/internal/status/aggregate.go
+++ b/internal/status/aggregate.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/conditions"
+)
+
+// BindingAggregation holds the aggregated binding information
+type BindingAggregation struct {
+	Ready    bool
+	Reason   string
+	Message  string
+	Bindings []scorev1b1.BindingSummary
+}
+
+// AggregateBindingStatuses processes all ResourceBindings and returns aggregated status
+func AggregateBindingStatuses(bindings []scorev1b1.ResourceBinding) BindingAggregation {
+	if len(bindings) == 0 {
+		return BindingAggregation{
+			Ready:    false,
+			Reason:   conditions.ReasonBindingPending,
+			Message:  conditions.MessageNoBindingsFound,
+			Bindings: []scorev1b1.BindingSummary{},
+		}
+	}
+
+	summaries := make([]scorev1b1.BindingSummary, 0, len(bindings))
+	var boundCount, failedCount int
+
+	for _, binding := range bindings {
+		summary := scorev1b1.BindingSummary{
+			Key:              binding.Spec.Key,
+			Phase:            binding.Status.Phase,
+			Reason:           binding.Status.Reason,
+			Message:          binding.Status.Message,
+			OutputsAvailable: binding.Status.OutputsAvailable,
+		}
+
+		// Handle empty phase as Pending
+		if summary.Phase == "" {
+			summary.Phase = scorev1b1.ResourceBindingPhasePending
+		}
+
+		summaries = append(summaries, summary)
+
+		// Count phases for overall status
+		switch binding.Status.Phase {
+		case scorev1b1.ResourceBindingPhaseBound:
+			if binding.Status.OutputsAvailable {
+				boundCount++
+			}
+		case scorev1b1.ResourceBindingPhaseFailed:
+			failedCount++
+		}
+	}
+
+	// Determine overall binding readiness
+	totalBindings := len(bindings)
+	var ready bool
+	var reason, message string
+
+	if failedCount > 0 {
+		ready = false
+		reason = conditions.ReasonBindingFailed
+		message = conditions.MessageBindingsFailed
+	} else if boundCount == totalBindings {
+		ready = true
+		reason = conditions.ReasonSucceeded
+		message = conditions.MessageAllBindingsReady
+	} else {
+		ready = false
+		reason = conditions.ReasonBindingPending
+		message = conditions.MessageBindingsProvisioning
+	}
+
+	return BindingAggregation{
+		Ready:    ready,
+		Reason:   reason,
+		Message:  message,
+		Bindings: summaries,
+	}
+}
+
+// UpdateWorkloadStatusFromAggregation updates the Workload status based on binding aggregation
+func UpdateWorkloadStatusFromAggregation(workload *scorev1b1.Workload, agg BindingAggregation) {
+	// Update bindings summary
+	workload.Status.Bindings = agg.Bindings
+
+	// Update BindingsReady condition
+	var status metav1.ConditionStatus
+	if agg.Ready {
+		status = metav1.ConditionTrue
+	} else {
+		status = metav1.ConditionFalse
+	}
+
+	conditions.SetCondition(&workload.Status.Conditions,
+		conditions.ConditionBindingsReady,
+		status,
+		agg.Reason,
+		agg.Message)
+}


### PR DESCRIPTION
Add Orchestrator as single writer of Workload.status with abstract
platform-agnostic conditions and comprehensive resource orchestration.

Enables unified workload management across different runtime platforms
while maintaining clean separation between orchestration logic and
platform-specific implementations.