### PR TITLE
docs: normalize ResourceBinding to ResourceClaim terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Score defines a portable way to describe applications. This project provides a s
 ## What this project is
 - A reference **orchestrator** built around Kubernetes CRDs (group/version: `score.dev/v1b1`)
 - Public API surface: **`Workload`** only
-- Internal contracts for platform use: `ResourceBinding`, `WorkloadPlan`
+- Internal contracts for platform use: `ResourceClaim`, `WorkloadPlan`
 - Status is abstract and user-centric (a single `endpoint`, abstract `conditions`, binding summaries)
 - Validation boundary: **CRD OpenAPI + CEL** for spec invariants; org policy via **VAP/OPA/Kyverno**
 

--- a/docs/ADR/ADR-0003-architecture-simplification.md
+++ b/docs/ADR/ADR-0003-architecture-simplification.md
@@ -12,19 +12,21 @@
 Early drafts introduced policy/projection/provisioning overlaps (e.g., PlatformPolicy vs WorkloadPlan). We aim to keep "Workload-only" UX while reducing CRDs and aligning with score-k8s (provisioners, generate→patch→apply).
 
 ## Decision
-1) Keep `Workload` only for users  
-2) Remove `PlatformPolicy` CRD (policy = Orchestrator Config + Admission)  
-3) Keep internal: `ResourceClaim`, `WorkloadPlan`  
-4) External term = **provisioner** (resolver is internal wording)  
-5) **Workload profiles** = concept only (ConfigMap/OCI template bundles)  
-6) Default auto-selection; optional abstract hints via annotation  
-7) Orchestrator: select & build IR; Runtime: render/apply; single-writer status
+1) Keep `Workload` only for users
+2) Remove `PlatformPolicy` CRD (policy = Orchestrator Config + Admission)
+3) Keep internal: `ResourceClaim`, `WorkloadPlan`
+4) Rename `ResourceBinding` → `ResourceClaim` for clarity (claiming dependencies vs binding execution)
+5) External term = **provisioner** (resolver is internal wording)
+6) **Workload profiles** = concept only (ConfigMap/OCI template bundles)
+7) Default auto-selection; optional abstract hints via annotation
+8) Orchestrator: select & build IR; Runtime: render/apply; single-writer status
 
 ## Rationale
 - Reduce confusion (policy vs plan vs template)
 - Align with score-k8s mental model
 - Backend choice is encapsulated; users stay runtime-agnostic
 - Fewer public CRDs; distribution via OCI/ConfigMap
+- `ResourceClaim` better reflects intent: claiming/requesting dependencies rather than binding execution state
 
 ## Details
 
@@ -92,7 +94,7 @@ A single **orchestrator config** (ConfigMap or OCI document) becomes the source 
 |  (authors only    |  Workload | - reads Orchestrator    |  Plan/IR | - watches Plan/IR     |
 |   Workload)       +---------->+   Config & Admission    +--------->+ - fetches template    |
 +-------------------+           | - selects Profile/Backend|          | - render & apply      |
-                                | - creates ResourceClaim|          | - diagnostics (internal)
+                                | - creates ResourceClaim  |          | - diagnostics (internal)
                                 | - builds WorkloadPlan    |          +-----------+-----------+
                                 | - updates Workload.status|                      |
                                 +-----------+--------------+                      |

--- a/docs/spec/control-plane.md
+++ b/docs/spec/control-plane.md
@@ -10,27 +10,27 @@ It complements:
 ## Controller-centric responsibilities (watch vs. write)
 
 ### Orchestrator (reference project, independent from Score Official)
-- **Watches:** `Workload`, `ResourceBinding`, `WorkloadPlan`
+- **Watches:** `Workload`, `ResourceClaim`, `WorkloadPlan`
 - **Reads:** **Orchestrator Config** (ConfigMap/OCI) and applies Admission
 - **Creates/updates (spec):**
-  - `ResourceBinding` — one per `Workload.spec.resources.<key>` (OwnerRef = Workload)
+  - `ResourceClaim` — one per `Workload.spec.resources.<key>` (OwnerRef = Workload)
   - `WorkloadPlan` — same name as the target Workload (OwnerRef = Workload)
 - **Updates (status):**
   - **`Workload.status`** — the *only* writer (exposes `endpoint`, abstract `conditions`, binding summaries)
 - **Finalization:**
-  - Adds a finalizer to `Workload` to ensure `ResourceBinding` deprovision completes before removal
+  - Adds a finalizer to `Workload` to ensure `ResourceClaim` deprovision completes before removal
 
 ### Provisioner (PF/vendor)
-- **Watches:** `ResourceBinding` for its `spec.type`; own `Secret/ConfigMap`; external service APIs as needed
+- **Watches:** `ResourceClaim` for its `spec.type`; own `Secret/ConfigMap`; external service APIs as needed
 - **Creates/updates (objects):** `Secret/ConfigMap` with credentials/config (same namespace)
-- **Updates (status):** `ResourceBinding.status` (`phase`, `reason`, `message`, `outputs`, timestamps)
-- **Produces image outputs (when applicable):** Provisioners for `image|build|buildpack` types publish an OCI reference as `ResourceBinding.status.outputs.image`.
+- **Updates (status):** `ResourceClaim.status` (`phase`, `reason`, `message`, `outputs`, timestamps)
+- **Produces image outputs (when applicable):** Provisioners for `image|build|buildpack` types publish an OCI reference as `ResourceClaim.status.outputs.image`.
 - **Plan linkage:** The Orchestrator emits a `WorkloadPlan` projection that binds that output into the final container image, e.g.:
   - `containers[].imageFrom: { bindingKey, outputKey: "image" }`
-- **Finalization:** On `ResourceBinding` deletion, deprovision external resources / Secrets, then remove finalizer
+- **Finalization:** On `ResourceClaim` deletion, deprovision external resources / Secrets, then remove finalizer
 
 ### Runtime Controller (PF)
-- **Watches:** `WorkloadPlan` (primary), `ResourceBinding` (consume `status.outputs`), `Workload` (labels/metadata)
+- **Watches:** `WorkloadPlan` (primary), `ResourceClaim` (consume `status.outputs`), `Workload` (labels/metadata)
 - **Creates/updates (objects):** runtime-specific child resources (e.g., Deployments/Services/etc. on Kubernetes)
 - **Updates (status):** *Does not write* `Workload.status`; may write its own internal report CR
 - **Finalization:** Cleans up runtime children when `WorkloadPlan` changes or is deleted
@@ -40,18 +40,18 @@ It complements:
 | Resource (`score.dev/v1b1`) | Read/watch                                 | Write (spec/create)           | Write (status)            | Notes |
 |---|---|---|---|---|
 | `Workload` (public)         | Orchestrator, Runtime                      | Users only                    | **Orchestrator only**     | Orchestrator attaches a finalizer to control deletion order |
-| `ResourceBinding` (internal) | Orchestrator, Provisioner, Runtime       | **Orchestrator**              | **Provisioner**           | One per `resources.<key>` |
+| `ResourceClaim` (internal) | Orchestrator, Provisioner, Runtime       | **Orchestrator**              | **Provisioner**           | One per `resources.<key>` |
 | `WorkloadPlan` (internal)   | Runtime, Orchestrator                      | **Orchestrator** (single writer) | —                      | Same name as Workload; OwnerRef = Workload |
 | `Secret/ConfigMap` (outputs) | Runtime (read), Orchestrator (not required) | **Provisioner**              | —                         | Same namespace; hidden from users |
 
 ## Binding ↔ Plan linkage (how they meet)
 - **Key-based mapping:** `WorkloadPlan.spec.projection` refers to dependencies by `bindingKey` (the key in `Workload.spec.resources`).  
-  Each `ResourceBinding` is created for that key; its `status.outputs` provide the concrete values.
+  Each `ResourceClaim` is created for that key; its `status.outputs` provide the concrete values.
 - **Separation of concerns:** Plan carries **how to use** (projection rules), Binding carries **what to provide** (outputs).
 
 **Example: Image resolution flow:**
 ```yaml
-# ResourceBinding.status.outputs (by Provisioner)
+# ResourceClaim.status.outputs (by Provisioner)
 outputs:
   image: "registry.example.com/myapp:v1.2.3"
 


### PR DESCRIPTION
Consistently use ResourceClaim instead of ResourceBinding across all documentation. Update corresponding condition names from BindingsReady to ClaimsReady. Add explicit decision rationale to ADR-0003 for terminology change.