### PR TITLE
feat: implement deterministic profile selection pipeline

### DIFF
--- a/config/samples/orchestrator-config.yaml
+++ b/config/samples/orchestrator-config.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: score-system
+  labels:
+    environment: development
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -18,44 +20,77 @@ data:
     spec:
       profiles:
       - name: web-service
-        description: "Web service profile"
+        description: "HTTP-based web applications"
         backends:
-        - backendId: k8s-web-1
+        - backendId: k8s-web-dev
           runtimeClass: kubernetes
           template:
             kind: manifests
             ref: "registry.example.com/templates/web@sha256:abc123"
             values:
-              replicas: 3
-          priority: 100
+              replicas: 1
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "128Mi"
+          priority: 50
           version: "1.0.0"
-      - name: database-service
-        description: "Database service profile"
-        backends:
-        - backendId: k8s-db-1
+          constraints:
+            selectors:
+            - matchLabels:
+                environment: development
+            features: ["http-ingress"]
+        - backendId: k8s-web-prod
           runtimeClass: kubernetes
           template:
             kind: manifests
-            ref: "registry.example.com/templates/db@sha256:def456"
+            ref: "registry.example.com/templates/web-prod@sha256:def456"
             values:
-              storage: "10Gi"
-          priority: 90
+              replicas: 3
+              resources:
+                requests:
+                  cpu: "200m"
+                  memory: "256Mi"
+          priority: 100
+          version: "1.2.0"
+          constraints:
+            selectors:
+            - matchLabels:
+                environment: production
+            features: ["http-ingress", "monitoring"]
+      - name: batch-job
+        description: "Batch processing workloads"
+        backends:
+        - backendId: k8s-batch-standard
+          runtimeClass: kubernetes
+          template:
+            kind: manifests
+            ref: "registry.example.com/templates/batch@sha256:ghi789"
+            values:
+              restartPolicy: OnFailure
+          priority: 100
           version: "1.0.0"
       provisioners:
       - type: postgres
         provisioner: postgres-operator
+        defaults:
+          class: small
         classes:
         - name: small
-          description: "Small database"
+          description: "Development database"
           parameters:
             cpu: "500m"
             memory: "1Gi"
             storage: "10Gi"
         - name: large
-          description: "Large database"
+          description: "Production database"
           parameters:
             cpu: "2000m"
             memory: "4Gi"
             storage: "100Gi"
       defaults:
         profile: web-service
+        selectors:
+        - matchLabels:
+            workload-type: batch
+          profile: batch-job

--- a/config/samples/score_v1b1_workload.yaml
+++ b/config/samples/score_v1b1_workload.yaml
@@ -1,3 +1,4 @@
+# Test Case 1: Auto-derivation - web service (has service ports)
 apiVersion: score.dev/v1b1
 kind: Workload
 metadata:
@@ -7,10 +8,39 @@ metadata:
   name: workload-sample
   namespace: score-system
 spec:
-  profile: web-service
   containers:
     app:
       image: nginx:latest
+  service:
+    ports:
+    - port: 8080
   resources:
     db:
       type: postgres
+---
+# Test Case 2: Selector matching - batch workload
+apiVersion: score.dev/v1b1
+kind: Workload
+metadata:
+  labels:
+    workload-type: batch
+  name: workload-batch
+  namespace: score-system
+spec:
+  containers:
+    worker:
+      image: busybox:latest
+      command: ["sleep", "3600"]
+---
+# Test Case 3: User hint - explicit profile annotation
+apiVersion: score.dev/v1b1
+kind: Workload
+metadata:
+  annotations:
+    score.dev/profile: "batch-job"
+  name: workload-user-hint
+  namespace: score-system
+spec:
+  containers:
+    app:
+      image: nginx:latest

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,20 @@ module github.com/cappyzawa/score-orchestrator
 go 1.24.5
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/onsi/ginkgo/v2 v2.25.1
 	github.com/onsi/gomega v1.38.1
+	github.com/stretchr/testify v1.10.0
+	k8s.io/api v0.33.0
 	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
 	sigs.k8s.io/controller-runtime v0.21.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
 	cel.dev/expr v0.19.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -49,6 +52,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
@@ -90,7 +94,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.33.0 // indirect
 	k8s.io/apiserver v0.33.0 // indirect
 	k8s.io/component-base v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
@@ -101,7 +104,6 @@ require (
 	sigs.k8s.io/kubebuilder/v4 v4.8.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 tool sigs.k8s.io/kubebuilder/v4

--- a/internal/selection/label.go
+++ b/internal/selection/label.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+// combineLabels combines workload and namespace labels following the normative rule:
+// "Selectors are evaluated against the union of Workload.metadata.labels and the target
+// Namespace.metadata.labels. If a key exists in both, the Workload label value takes precedence."
+func combineLabels(workloadLabels, namespaceLabels map[string]string) map[string]string {
+	result := make(map[string]string)
+
+	// First, add all namespace labels
+	for key, value := range namespaceLabels {
+		result[key] = value
+	}
+
+	// Then add workload labels, overriding namespace labels if keys conflict
+	for key, value := range workloadLabels {
+		result[key] = value
+	}
+
+	return result
+}

--- a/internal/selection/label_test.go
+++ b/internal/selection/label_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCombineLabels(t *testing.T) {
+	tests := []struct {
+		name            string
+		workloadLabels  map[string]string
+		namespaceLabels map[string]string
+		expected        map[string]string
+	}{
+		{
+			name: "workload labels take precedence over namespace labels",
+			workloadLabels: map[string]string{
+				"app":         "myapp",
+				"environment": "staging", // conflicts with namespace
+			},
+			namespaceLabels: map[string]string{
+				"environment": "production", // should be overridden
+				"team":        "backend",
+			},
+			expected: map[string]string{
+				"app":         "myapp",
+				"environment": "staging", // workload wins
+				"team":        "backend",
+			},
+		},
+		{
+			name:           "only namespace labels",
+			workloadLabels: nil,
+			namespaceLabels: map[string]string{
+				"environment": "production",
+				"team":        "backend",
+			},
+			expected: map[string]string{
+				"environment": "production",
+				"team":        "backend",
+			},
+		},
+		{
+			name: "only workload labels",
+			workloadLabels: map[string]string{
+				"app":     "myapp",
+				"version": "1.0.0",
+			},
+			namespaceLabels: nil,
+			expected: map[string]string{
+				"app":     "myapp",
+				"version": "1.0.0",
+			},
+		},
+		{
+			name:            "both nil",
+			workloadLabels:  nil,
+			namespaceLabels: nil,
+			expected:        map[string]string{},
+		},
+		{
+			name:            "empty maps",
+			workloadLabels:  map[string]string{},
+			namespaceLabels: map[string]string{},
+			expected:        map[string]string{},
+		},
+		{
+			name: "no conflicts",
+			workloadLabels: map[string]string{
+				"app":     "myapp",
+				"version": "1.0.0",
+			},
+			namespaceLabels: map[string]string{
+				"environment": "production",
+				"team":        "backend",
+			},
+			expected: map[string]string{
+				"app":         "myapp",
+				"version":     "1.0.0",
+				"environment": "production",
+				"team":        "backend",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := combineLabels(tt.workloadLabels, tt.namespaceLabels)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/selection/selector.go
+++ b/internal/selection/selector.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+)
+
+// SelectedBackend represents the result of backend selection
+type SelectedBackend struct {
+	BackendID    string
+	RuntimeClass string
+	Template     scorev1b1.TemplateSpec
+	Priority     int
+	Version      string
+}
+
+// ProfileSelector interface defines the contract for profile and backend selection
+type ProfileSelector interface {
+	// SelectBackend selects the appropriate backend for a workload based on the
+	// deterministic selection pipeline specified in the orchestrator config spec
+	SelectBackend(ctx context.Context, workload *scorev1b1.Workload) (*SelectedBackend, error)
+}
+
+// profileSelector implements ProfileSelector interface
+type profileSelector struct {
+	config *scorev1b1.OrchestratorConfig
+	client client.Client
+}
+
+// NewProfileSelector creates a new ProfileSelector instance
+func NewProfileSelector(config *scorev1b1.OrchestratorConfig, k8sClient client.Client) ProfileSelector {
+	return &profileSelector{
+		config: config,
+		client: k8sClient,
+	}
+}
+
+// SelectBackend implements the deterministic selection pipeline:
+// 1. Profile Selection (user hint → auto-derive → selectors → global default)
+// 2. Backend Filtering (selectors, features, constraints, admission)
+// 3. Backend Selection (deterministic sorting by priority → version → backendId)
+func (s *profileSelector) SelectBackend(ctx context.Context, workload *scorev1b1.Workload) (*SelectedBackend, error) {
+	// 1. Profile Selection
+	profileName, err := s.selectProfile(ctx, workload)
+	if err != nil {
+		return nil, fmt.Errorf("profile selection failed: %w", err)
+	}
+
+	// Find the selected profile
+	var selectedProfile *scorev1b1.ProfileSpec
+	for _, profile := range s.config.Spec.Profiles {
+		if profile.Name == profileName {
+			selectedProfile = &profile
+			break
+		}
+	}
+
+	if selectedProfile == nil {
+		return nil, fmt.Errorf("profile %q not found in configuration", profileName)
+	}
+
+	// 2. Backend Filtering
+	candidates, err := s.filterBackends(ctx, workload, selectedProfile.Backends)
+	if err != nil {
+		return nil, fmt.Errorf("backend filtering failed: %w", err)
+	}
+
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no suitable backend candidates found for profile %q", profileName)
+	}
+
+	// 3. Backend Selection
+	selectedBackend := s.selectBackend(candidates)
+
+	return &SelectedBackend{
+		BackendID:    selectedBackend.BackendId,
+		RuntimeClass: selectedBackend.RuntimeClass,
+		Template:     selectedBackend.Template,
+		Priority:     selectedBackend.Priority,
+		Version:      selectedBackend.Version,
+	}, nil
+}
+
+// selectProfile implements the profile selection pipeline
+func (s *profileSelector) selectProfile(ctx context.Context, workload *scorev1b1.Workload) (string, error) {
+	// 1. User hint evaluation: score.dev/profile annotation on Workload
+	if profileHint, exists := workload.Annotations["score.dev/profile"]; exists && profileHint != "" {
+		// Validate that the hinted profile exists
+		for _, profile := range s.config.Spec.Profiles {
+			if profile.Name == profileHint {
+				return profileHint, nil
+			}
+		}
+		// Profile hint is invalid - this should result in SpecInvalid
+		return "", fmt.Errorf("hinted profile %q does not exist", profileHint)
+	}
+
+	// 2. Auto-derivation: Profile inferred from Workload characteristics
+	if derivedProfile := s.deriveProfileFromWorkload(workload); derivedProfile != "" {
+		return derivedProfile, nil
+	}
+
+	// 3. Selector matching: Apply defaults.selectors[] based on namespace/labels
+	selectedProfile, err := s.selectProfileFromSelectors(ctx, workload)
+	if err != nil {
+		return "", fmt.Errorf("selector matching failed: %w", err)
+	}
+	if selectedProfile != "" {
+		return selectedProfile, nil
+	}
+
+	// 4. Global fallback: Use defaults.profile as final fallback
+	if s.config.Spec.Defaults.Profile != "" {
+		return s.config.Spec.Defaults.Profile, nil
+	}
+
+	return "", fmt.Errorf("no profile could be determined and no default profile is configured")
+}
+
+// deriveProfileFromWorkload derives profile from workload characteristics
+func (s *profileSelector) deriveProfileFromWorkload(workload *scorev1b1.Workload) string {
+	// Auto-derivation rules (basic implementation):
+	// - If workload has service ports: likely web-service
+	// - If workload has no service: likely batch-job
+
+	if workload.Spec.Service != nil && len(workload.Spec.Service.Ports) > 0 {
+		// Look for web-service profile
+		for _, profile := range s.config.Spec.Profiles {
+			if strings.Contains(strings.ToLower(profile.Name), "web") ||
+				strings.Contains(strings.ToLower(profile.Name), "service") {
+				return profile.Name
+			}
+		}
+	} else {
+		// Look for batch-job profile
+		for _, profile := range s.config.Spec.Profiles {
+			if strings.Contains(strings.ToLower(profile.Name), "batch") ||
+				strings.Contains(strings.ToLower(profile.Name), "job") {
+				return profile.Name
+			}
+		}
+	}
+
+	return ""
+}
+
+// selectProfileFromSelectors evaluates defaults.selectors[] in document order
+func (s *profileSelector) selectProfileFromSelectors(ctx context.Context, workload *scorev1b1.Workload) (string, error) {
+	// Get namespace labels
+	namespace := &corev1.Namespace{}
+	if err := s.client.Get(ctx, client.ObjectKey{Name: workload.Namespace}, namespace); err != nil {
+		return "", fmt.Errorf("failed to get namespace %q: %w", workload.Namespace, err)
+	}
+
+	// Combine labels: Workload ∪ Namespace (Workload takes precedence)
+	combinedLabels := combineLabels(workload.Labels, namespace.Labels)
+
+	// Evaluate selectors in document order - first match wins
+	for _, selector := range s.config.Spec.Defaults.Selectors {
+		if s.selectorMatches(selector, combinedLabels) && selector.Profile != "" {
+			return selector.Profile, nil
+		}
+	}
+
+	return "", nil
+}
+
+// selectorMatches checks if a selector matches the given labels
+func (s *profileSelector) selectorMatches(selector scorev1b1.SelectorSpec, targetLabels map[string]string) bool {
+	// Convert to metav1.LabelSelector for standard matching logic
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels:      selector.MatchLabels,
+		MatchExpressions: selector.MatchExpressions,
+	}
+
+	parsedSelector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return false
+	}
+
+	return parsedSelector.Matches(labels.Set(targetLabels))
+}
+
+// filterBackends applies filtering to backend candidates
+func (s *profileSelector) filterBackends(ctx context.Context, workload *scorev1b1.Workload, backends []scorev1b1.BackendSpec) ([]scorev1b1.BackendSpec, error) {
+	candidates := make([]scorev1b1.BackendSpec, 0, len(backends))
+
+	// Get namespace labels for constraint evaluation
+	namespace := &corev1.Namespace{}
+	if err := s.client.Get(ctx, client.ObjectKey{Name: workload.Namespace}, namespace); err != nil {
+		return nil, fmt.Errorf("failed to get namespace %q: %w", workload.Namespace, err)
+	}
+
+	combinedLabels := combineLabels(workload.Labels, namespace.Labels)
+
+	for _, backend := range backends {
+		// Apply environment selectors (skip if no constraints)
+		if backend.Constraints != nil && !s.backendSelectorsMatch(backend.Constraints.Selectors, combinedLabels) {
+			continue
+		}
+
+		// Validate feature requirements (skip if no constraints)
+		if backend.Constraints != nil && !s.validateFeatureRequirements(workload, backend.Constraints.Features) {
+			continue
+		}
+
+		// Check resource constraints (skip if no constraints)
+		if backend.Constraints != nil && backend.Constraints.Resources != nil && !s.validateResourceConstraints(workload, *backend.Constraints.Resources) {
+			continue
+		}
+
+		// Backend passes all filters
+		candidates = append(candidates, backend)
+	}
+
+	return candidates, nil
+}
+
+// backendSelectorsMatch checks if backend constraint selectors match
+func (s *profileSelector) backendSelectorsMatch(selectors []scorev1b1.SelectorSpec, targetLabels map[string]string) bool {
+	// If no selectors specified, backend matches all environments
+	if len(selectors) == 0 {
+		return true
+	}
+
+	// At least one selector must match
+	for _, selector := range selectors {
+		if s.selectorMatches(selector, targetLabels) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// validateFeatureRequirements validates features against workload requirements
+func (s *profileSelector) validateFeatureRequirements(workload *scorev1b1.Workload, requiredFeatures []string) bool {
+	if len(requiredFeatures) == 0 {
+		return true
+	}
+
+	// Get workload feature requirements from annotation
+	requirementsAnnotation, exists := workload.Annotations["score.dev/requirements"]
+	if !exists {
+		return len(requiredFeatures) == 0
+	}
+
+	workloadFeatures := strings.Split(requirementsAnnotation, ",")
+	workloadFeatureSet := make(map[string]bool)
+	for _, feature := range workloadFeatures {
+		workloadFeatureSet[strings.TrimSpace(feature)] = true
+	}
+
+	// All required features must be present in workload requirements
+	for _, required := range requiredFeatures {
+		if !workloadFeatureSet[required] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// validateResourceConstraints validates resource constraints (placeholder implementation)
+func (s *profileSelector) validateResourceConstraints(workload *scorev1b1.Workload, constraints scorev1b1.ResourceConstraints) bool {
+	// For MVP: basic validation - could be enhanced with proper quantity parsing
+	// This is a simplified implementation for now
+	return true
+}
+
+// selectBackend performs deterministic backend selection with sorting
+func (s *profileSelector) selectBackend(candidates []scorev1b1.BackendSpec) scorev1b1.BackendSpec {
+	// Sort deterministically: priority (desc) → version (SemVer desc) → backendId (asc)
+	sort.Slice(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+
+		// 1. Priority comparison (higher priority wins)
+		if a.Priority != b.Priority {
+			return a.Priority > b.Priority
+		}
+
+		// 2. Version comparison (SemVer, newer wins)
+		versionA, errA := semver.NewVersion(a.Version)
+		versionB, errB := semver.NewVersion(b.Version)
+
+		if errA == nil && errB == nil {
+			cmp := versionA.Compare(versionB)
+			if cmp != 0 {
+				return cmp > 0 // newer version wins
+			}
+		} else if errA == nil && errB != nil {
+			return true // valid semver beats invalid
+		} else if errA != nil && errB == nil {
+			return false // invalid semver loses to valid
+		}
+		// If both invalid, fall through to backendId comparison
+
+		// 3. BackendId comparison (lexicographical, smaller wins for determinism)
+		return a.BackendId < b.BackendId
+	})
+
+	// Return the first (best) candidate
+	return candidates[0]
+}

--- a/internal/selection/selector_test.go
+++ b/internal/selection/selector_test.go
@@ -1,0 +1,546 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+)
+
+func TestProfileSelector_SelectBackend(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, scorev1b1.AddToScheme(scheme))
+
+	tests := []struct {
+		name        string
+		config      *scorev1b1.OrchestratorConfig
+		workload    *scorev1b1.Workload
+		namespace   *corev1.Namespace
+		wantBackend *SelectedBackend
+		wantErr     bool
+	}{
+		{
+			name: "user hint profile selection",
+			config: &scorev1b1.OrchestratorConfig{
+				Spec: scorev1b1.OrchestratorConfigSpec{
+					Profiles: []scorev1b1.ProfileSpec{
+						{
+							Name: "web-service",
+							Backends: []scorev1b1.BackendSpec{
+								{
+									BackendId:    "k8s-web",
+									RuntimeClass: "kubernetes",
+									Priority:     100,
+									Version:      "1.0.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"score.dev/profile": "web-service",
+					},
+				},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			},
+			wantBackend: &SelectedBackend{
+				BackendID:    "k8s-web",
+				RuntimeClass: "kubernetes",
+				Priority:     100,
+				Version:      "1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid user hint should fail",
+			config: &scorev1b1.OrchestratorConfig{
+				Spec: scorev1b1.OrchestratorConfigSpec{
+					Profiles: []scorev1b1.ProfileSpec{
+						{
+							Name: "web-service",
+							Backends: []scorev1b1.BackendSpec{
+								{
+									BackendId:    "k8s-web",
+									RuntimeClass: "kubernetes",
+									Priority:     100,
+									Version:      "1.0.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"score.dev/profile": "nonexistent-profile",
+					},
+				},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "auto-derivation for web service",
+			config: &scorev1b1.OrchestratorConfig{
+				Spec: scorev1b1.OrchestratorConfigSpec{
+					Profiles: []scorev1b1.ProfileSpec{
+						{
+							Name: "web-service",
+							Backends: []scorev1b1.BackendSpec{
+								{
+									BackendId:    "k8s-web",
+									RuntimeClass: "kubernetes",
+									Priority:     100,
+									Version:      "1.0.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "default",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Service: &scorev1b1.ServiceSpec{
+						Ports: []scorev1b1.ServicePort{
+							{Port: 8080},
+						},
+					},
+				},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			},
+			wantBackend: &SelectedBackend{
+				BackendID:    "k8s-web",
+				RuntimeClass: "kubernetes",
+				Priority:     100,
+				Version:      "1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "selector matching with combined labels",
+			config: &scorev1b1.OrchestratorConfig{
+				Spec: scorev1b1.OrchestratorConfigSpec{
+					Profiles: []scorev1b1.ProfileSpec{
+						{
+							Name: "dev-service",
+							Backends: []scorev1b1.BackendSpec{
+								{
+									BackendId:    "k8s-dev",
+									RuntimeClass: "kubernetes",
+									Priority:     50,
+									Version:      "1.0.0",
+								},
+							},
+						},
+					},
+					Defaults: scorev1b1.DefaultsSpec{
+						Selectors: []scorev1b1.SelectorSpec{
+							{
+								MatchLabels: map[string]string{
+									"environment": "development",
+								},
+								Profile: "dev-service",
+							},
+						},
+					},
+				},
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "myapp",
+					},
+				},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+					Labels: map[string]string{
+						"environment": "development",
+					},
+				},
+			},
+			wantBackend: &SelectedBackend{
+				BackendID:    "k8s-dev",
+				RuntimeClass: "kubernetes",
+				Priority:     50,
+				Version:      "1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "global default profile",
+			config: &scorev1b1.OrchestratorConfig{
+				Spec: scorev1b1.OrchestratorConfigSpec{
+					Profiles: []scorev1b1.ProfileSpec{
+						{
+							Name: "default-profile",
+							Backends: []scorev1b1.BackendSpec{
+								{
+									BackendId:    "k8s-default",
+									RuntimeClass: "kubernetes",
+									Priority:     10,
+									Version:      "1.0.0",
+								},
+							},
+						},
+					},
+					Defaults: scorev1b1.DefaultsSpec{
+						Profile: "default-profile",
+					},
+				},
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "default",
+				},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			},
+			wantBackend: &SelectedBackend{
+				BackendID:    "k8s-default",
+				RuntimeClass: "kubernetes",
+				Priority:     10,
+				Version:      "1.0.0",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.namespace).
+				Build()
+
+			selector := NewProfileSelector(tt.config, fakeClient)
+
+			result, err := selector.SelectBackend(context.Background(), tt.workload)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantBackend.BackendID, result.BackendID)
+			assert.Equal(t, tt.wantBackend.RuntimeClass, result.RuntimeClass)
+			assert.Equal(t, tt.wantBackend.Priority, result.Priority)
+			assert.Equal(t, tt.wantBackend.Version, result.Version)
+		})
+	}
+}
+
+func TestProfileSelector_DeterministicBackendSelection(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, scorev1b1.AddToScheme(scheme))
+
+	tests := []struct {
+		name       string
+		backends   []scorev1b1.BackendSpec
+		expectedId string
+	}{
+		{
+			name: "priority sorting (higher wins)",
+			backends: []scorev1b1.BackendSpec{
+				{BackendId: "low", Priority: 10, Version: "1.0.0"},
+				{BackendId: "high", Priority: 100, Version: "1.0.0"},
+				{BackendId: "medium", Priority: 50, Version: "1.0.0"},
+			},
+			expectedId: "high",
+		},
+		{
+			name: "version sorting when priority equal (newer wins)",
+			backends: []scorev1b1.BackendSpec{
+				{BackendId: "old", Priority: 100, Version: "1.0.0"},
+				{BackendId: "new", Priority: 100, Version: "2.0.0"},
+				{BackendId: "middle", Priority: 100, Version: "1.5.0"},
+			},
+			expectedId: "new",
+		},
+		{
+			name: "release beats prerelease",
+			backends: []scorev1b1.BackendSpec{
+				{BackendId: "prerelease", Priority: 100, Version: "1.0.0-rc.1"},
+				{BackendId: "release", Priority: 100, Version: "1.0.0"},
+			},
+			expectedId: "release",
+		},
+		{
+			name: "backendId tie-breaking when priority and version equal",
+			backends: []scorev1b1.BackendSpec{
+				{BackendId: "zebra", Priority: 100, Version: "1.0.0"},
+				{BackendId: "alpha", Priority: 100, Version: "1.0.0"},
+				{BackendId: "beta", Priority: 100, Version: "1.0.0"},
+			},
+			expectedId: "alpha", // lexicographically first
+		},
+		{
+			name: "complex sorting with all criteria",
+			backends: []scorev1b1.BackendSpec{
+				{BackendId: "low-new", Priority: 10, Version: "2.0.0"},
+				{BackendId: "high-old-z", Priority: 100, Version: "1.0.0"},
+				{BackendId: "high-old-a", Priority: 100, Version: "1.0.0"},
+				{BackendId: "high-new", Priority: 100, Version: "2.0.0"},
+			},
+			expectedId: "high-new", // highest priority, newest version
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &scorev1b1.OrchestratorConfig{
+				Spec: scorev1b1.OrchestratorConfigSpec{
+					Profiles: []scorev1b1.ProfileSpec{
+						{
+							Name:     "test-profile",
+							Backends: tt.backends,
+						},
+					},
+					Defaults: scorev1b1.DefaultsSpec{
+						Profile: "test-profile",
+					},
+				},
+			}
+
+			workload := &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "default",
+				},
+			}
+
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(namespace).
+				Build()
+
+			selector := NewProfileSelector(config, fakeClient)
+			result, err := selector.SelectBackend(context.Background(), workload)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedId, result.BackendID)
+		})
+	}
+}
+
+func TestProfileSelector_BackendFiltering(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, scorev1b1.AddToScheme(scheme))
+
+	tests := []struct {
+		name        string
+		backends    []scorev1b1.BackendSpec
+		workload    *scorev1b1.Workload
+		namespace   *corev1.Namespace
+		expectedId  string
+		expectError bool
+	}{
+		{
+			name: "selector filtering",
+			backends: []scorev1b1.BackendSpec{
+				{
+					BackendId:    "prod-only",
+					RuntimeClass: "kubernetes",
+					Priority:     100,
+					Version:      "1.0.0",
+					Constraints: &scorev1b1.ConstraintsSpec{
+						Selectors: []scorev1b1.SelectorSpec{
+							{
+								MatchLabels: map[string]string{
+									"environment": "production",
+								},
+							},
+						},
+					},
+				},
+				{
+					BackendId:    "dev-only",
+					RuntimeClass: "kubernetes",
+					Priority:     50,
+					Version:      "1.0.0",
+					Constraints: &scorev1b1.ConstraintsSpec{
+						Selectors: []scorev1b1.SelectorSpec{
+							{
+								MatchLabels: map[string]string{
+									"environment": "development",
+								},
+							},
+						},
+					},
+				},
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "default",
+				},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+					Labels: map[string]string{
+						"environment": "development",
+					},
+				},
+			},
+			expectedId: "dev-only",
+		},
+		{
+			name: "feature requirement filtering",
+			backends: []scorev1b1.BackendSpec{
+				{
+					BackendId:    "feature-required",
+					RuntimeClass: "kubernetes",
+					Priority:     100,
+					Version:      "1.0.0",
+					Constraints: &scorev1b1.ConstraintsSpec{
+						Features: []string{"http-ingress", "auto-scaling"},
+					},
+				},
+				{
+					BackendId:    "no-features",
+					RuntimeClass: "kubernetes",
+					Priority:     50,
+					Version:      "1.0.0",
+				},
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"score.dev/requirements": "http-ingress,auto-scaling",
+					},
+				},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			},
+			expectedId: "feature-required",
+		},
+		{
+			name: "no candidates after filtering",
+			backends: []scorev1b1.BackendSpec{
+				{
+					BackendId:    "prod-only",
+					RuntimeClass: "kubernetes",
+					Priority:     100,
+					Version:      "1.0.0",
+					Constraints: &scorev1b1.ConstraintsSpec{
+						Selectors: []scorev1b1.SelectorSpec{
+							{
+								MatchLabels: map[string]string{
+									"environment": "production",
+								},
+							},
+						},
+					},
+				},
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "default",
+				},
+			},
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+					Labels: map[string]string{
+						"environment": "development", // doesn't match prod-only
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &scorev1b1.OrchestratorConfig{
+				Spec: scorev1b1.OrchestratorConfigSpec{
+					Profiles: []scorev1b1.ProfileSpec{
+						{
+							Name:     "test-profile",
+							Backends: tt.backends,
+						},
+					},
+					Defaults: scorev1b1.DefaultsSpec{
+						Profile: "test-profile",
+					},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.namespace).
+				Build()
+
+			selector := NewProfileSelector(config, fakeClient)
+			result, err := selector.SelectBackend(context.Background(), tt.workload)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedId, result.BackendID)
+		})
+	}
+}


### PR DESCRIPTION
Implement the complete deterministic profile selection pipeline specified in issue #13 and ADR-0003 Orchestrator Config.

The ProfileSelector implements a four-stage selection process:
1. User hint evaluation (score.dev/profile annotation)
2. Auto-derivation from workload characteristics
3. Selector matching against namespace/workload labels
4. Global default fallback

Backend filtering applies environment selectors, feature requirements, and resource constraints. Final selection uses deterministic sorting by priority, semver version, and backendId.

This replaces hardcoded runtime selection with a flexible, configuration-driven approach supporting multi-environment deployments and team-specific optimizations.