### PR TITLE
feat: implement WorkloadPlan generation with template handling

### DIFF
--- a/api/v1b1/workloadplan_types.go
+++ b/api/v1b1/workloadplan_types.go
@@ -19,6 +19,7 @@ package v1b1
 import (
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true
@@ -41,8 +42,8 @@ type WorkloadPlanWorkloadRef struct {
 
 // FromBindingOutput references a single output key produced by a binding.
 type FromBindingOutput struct {
-	// BindingKey is the key under Workload.spec.resources (e.g., "db").
-	BindingKey string `json:"bindingKey"`
+	// ClaimKey is the key under Workload.spec.resources (e.g., "db").
+	ClaimKey string `json:"claimKey"`
 	// OutputKey is the output field exported by the binding (e.g., "uri").
 	OutputKey string `json:"outputKey"`
 }
@@ -100,6 +101,10 @@ type WorkloadPlanSpec struct {
 	ObservedWorkloadGeneration int64 `json:"observedWorkloadGeneration"`
 	// RuntimeClass is the selected runtime controller class.
 	RuntimeClass string `json:"runtimeClass"`
+	// Template contains the reference and type information for runtime materialization.
+	Template *TemplateSpec `json:"template,omitempty"`
+	// Values contains the composed template values (defaults ⊕ normalize(Workload) ⊕ outputs).
+	Values *runtime.RawExtension `json:"values,omitempty"`
 	// Projection defines how binding outputs are injected into the workload.
 	Projection WorkloadProjection `json:"projection,omitempty"`
 	// Bindings declares resource requirements to be materialized by the runtime.

--- a/api/v1b1/zz_generated.deepcopy.go
+++ b/api/v1b1/zz_generated.deepcopy.go
@@ -1051,6 +1051,16 @@ func (in *WorkloadPlanList) DeepCopyObject() runtime.Object {
 func (in *WorkloadPlanSpec) DeepCopyInto(out *WorkloadPlanSpec) {
 	*out = *in
 	out.WorkloadRef = in.WorkloadRef
+	if in.Template != nil {
+		in, out := &in.Template, &out.Template
+		*out = new(TemplateSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Values != nil {
+		in, out := &in.Values, &out.Values
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	in.Projection.DeepCopyInto(&out.Projection)
 	if in.Bindings != nil {
 		in, out := &in.Bindings, &out.Bindings

--- a/config/crd/bases/score.dev_workloadplans.yaml
+++ b/config/crd/bases/score.dev_workloadplans.yaml
@@ -89,8 +89,8 @@ spec:
                         from:
                           description: From selects the binding output to inject.
                           properties:
-                            bindingKey:
-                              description: BindingKey is the key under Workload.spec.resources
+                            claimKey:
+                              description: ClaimKey is the key under Workload.spec.resources
                                 (e.g., "db").
                               type: string
                             outputKey:
@@ -98,7 +98,7 @@ spec:
                                 by the binding (e.g., "uri").
                               type: string
                           required:
-                          - bindingKey
+                          - claimKey
                           - outputKey
                           type: object
                         name:
@@ -118,8 +118,8 @@ spec:
                           description: From selects the binding output to write to
                             the path.
                           properties:
-                            bindingKey:
-                              description: BindingKey is the key under Workload.spec.resources
+                            claimKey:
+                              description: ClaimKey is the key under Workload.spec.resources
                                 (e.g., "db").
                               type: string
                             outputKey:
@@ -127,7 +127,7 @@ spec:
                                 by the binding (e.g., "uri").
                               type: string
                           required:
-                          - bindingKey
+                          - claimKey
                           - outputKey
                           type: object
                         path:
@@ -144,8 +144,8 @@ spec:
                           description: From selects the binding output to project
                             into the volume.
                           properties:
-                            bindingKey:
-                              description: BindingKey is the key under Workload.spec.resources
+                            claimKey:
+                              description: ClaimKey is the key under Workload.spec.resources
                                 (e.g., "db").
                               type: string
                             outputKey:
@@ -153,7 +153,7 @@ spec:
                                 by the binding (e.g., "uri").
                               type: string
                           required:
-                          - bindingKey
+                          - claimKey
                           - outputKey
                           type: object
                         name:
@@ -165,6 +165,30 @@ spec:
               runtimeClass:
                 description: RuntimeClass is the selected runtime controller class.
                 type: string
+              template:
+                description: Template contains the reference and type information
+                  for runtime materialization.
+                properties:
+                  kind:
+                    description: 'Kind is the template type: "manifests" | "helm"
+                      | "kustomize"'
+                    type: string
+                  ref:
+                    description: Ref is the immutable reference (OCI digest recommended)
+                    type: string
+                  values:
+                    description: Values are optional default template values
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                required:
+                - kind
+                - ref
+                type: object
+              values:
+                description: Values contains the composed template values (defaults
+                  ⊕ normalize(Workload) ⊕ outputs).
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               workloadRef:
                 description: WorkloadRef identifies the source Workload of this plan.
                 properties:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,6 +2,7 @@
 resources:
 - orchestrator-config.yaml
 - score_v1b1_workload.yaml
-- score_v1b1_resourceclaim.yaml
-- score_v1b1_workloadplan.yaml
+# Internal resources - generated automatically by controller
+# - score_v1b1_resourceclaim.yaml
+# - score_v1b1_workloadplan.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/internal/reconcile/plan.go
+++ b/internal/reconcile/plan.go
@@ -19,6 +19,7 @@ package reconcile
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -28,21 +29,43 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/selection"
+)
+
+const (
+	outputKeyURI = "uri"
 )
 
 // UpsertWorkloadPlan creates or updates the WorkloadPlan for the given Workload
-func UpsertWorkloadPlan(ctx context.Context, c client.Client, workload *scorev1b1.Workload, claims []scorev1b1.ResourceClaim, runtimeClass string) error {
+func UpsertWorkloadPlan(ctx context.Context, c client.Client, workload *scorev1b1.Workload, claims []scorev1b1.ResourceClaim, selectedBackend *selection.SelectedBackend) error {
+	if workload.Name == "" {
+		return fmt.Errorf("workload name cannot be empty")
+	}
 	planName := workload.Name // Same name as Workload
+	if planName == "" {
+		return fmt.Errorf("plan name cannot be empty, workload.Name: %q", workload.Name)
+	}
 	plan := &scorev1b1.WorkloadPlan{}
 
 	// Try to get existing plan
-	err := c.Get(ctx, types.NamespacedName{
+	getErr := c.Get(ctx, types.NamespacedName{
 		Name:      planName,
 		Namespace: workload.Namespace,
 	}, plan)
 
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("failed to get WorkloadPlan %s: %w", planName, err)
+	if getErr != nil && !errors.IsNotFound(getErr) {
+		return fmt.Errorf("failed to get WorkloadPlan %s: %w", planName, getErr)
+	}
+
+	// Check for projection errors (missing outputs)
+	if err := validateProjectionRequirements(workload, claims); err != nil {
+		return fmt.Errorf("projection validation failed: %w", err)
+	}
+
+	// Compose values according to ADR-0003: defaults ⊕ normalize(Workload) ⊕ outputs
+	values, err := composeValues(selectedBackend.Template.Values, workload, claims)
+	if err != nil {
+		return fmt.Errorf("failed to compose template values: %w", err)
 	}
 
 	// Build the desired spec
@@ -52,14 +75,16 @@ func UpsertWorkloadPlan(ctx context.Context, c client.Client, workload *scorev1b
 			Namespace: workload.Namespace,
 		},
 		ObservedWorkloadGeneration: workload.Generation,
-		RuntimeClass:               runtimeClass,
+		RuntimeClass:               selectedBackend.RuntimeClass,
+		Template:                   &selectedBackend.Template,
+		Values:                     values,
 		Projection:                 buildProjection(workload, claims),
 		Bindings:                   buildPlanBindings(claims),
 	}
 
-	if errors.IsNotFound(err) {
+	if errors.IsNotFound(getErr) {
 		// Create new plan
-		plan = &scorev1b1.WorkloadPlan{
+		plan := &scorev1b1.WorkloadPlan{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      planName,
 				Namespace: workload.Namespace,
@@ -110,27 +135,295 @@ func UpsertWorkloadPlan(ctx context.Context, c client.Client, workload *scorev1b
 }
 
 // buildProjection creates the projection rules for injecting binding outputs
-func buildProjection(_ *scorev1b1.Workload, claims []scorev1b1.ResourceClaim) scorev1b1.WorkloadProjection {
+func buildProjection(workload *scorev1b1.Workload, claims []scorev1b1.ResourceClaim) scorev1b1.WorkloadProjection {
 	projection := scorev1b1.WorkloadProjection{}
 
-	// Build environment variable mappings
-	// This is a simplified projection - real implementation would need more sophisticated logic
+	// Build environment variable mappings from resource references in containers
+	envMappings := generateEnvMappings(workload, claims)
+	projection.Env = envMappings
+
+	// Build volume projections from container volume specifications
+	volumeProjections := generateVolumeProjections(workload, claims)
+	projection.Volumes = volumeProjections
+
+	// Build file projections from container file specifications
+	fileProjections := generateFileProjections(workload, claims)
+	projection.Files = fileProjections
+
+	return projection
+}
+
+// generateEnvMappings generates environment variable mappings based on Score placeholders in container variables
+func generateEnvMappings(workload *scorev1b1.Workload, claims []scorev1b1.ResourceClaim) []scorev1b1.EnvMapping {
+	var envMappings []scorev1b1.EnvMapping
+
+	// Create a map of available outputs for quick lookup
+	availableOutputs := make(map[string]map[string]bool)
 	for _, claim := range claims {
 		if claim.Status.OutputsAvailable {
-			// Create common environment variable mappings
-			// This is MVP implementation - more sophisticated mapping would be configurable
-			envVar := fmt.Sprintf("%s_URI", strings.ToUpper(claim.Spec.Key))
-			projection.Env = append(projection.Env, scorev1b1.EnvMapping{
-				Name: envVar,
-				From: scorev1b1.FromBindingOutput{
-					BindingKey: claim.Spec.Key,
-					OutputKey:  "uri", // Common output key
-				},
-			})
+			outputs := make(map[string]bool)
+			if claim.Status.Outputs.URI != nil {
+				outputs[outputKeyURI] = true
+			}
+			if claim.Status.Outputs.SecretRef != nil {
+				outputs["secretRef"] = true
+			}
+			if claim.Status.Outputs.ConfigMapRef != nil {
+				outputs["configMapRef"] = true
+			}
+			if claim.Status.Outputs.Image != nil {
+				outputs["image"] = true
+			}
+			if claim.Status.Outputs.Cert != nil {
+				outputs["cert"] = true
+			}
+			availableOutputs[claim.Spec.Key] = outputs
 		}
 	}
 
-	return projection
+	// Regular expression to match ${resources.<key>.outputs.<name>} patterns
+	resourceRefPattern := regexp.MustCompile(`\$\{resources\.([^.]+)\.outputs\.([^}]+)\}`)
+
+	// Scan all container environment variables for resource references
+	for _, container := range workload.Spec.Containers {
+		if container.Variables != nil {
+			for envName, envValue := range container.Variables {
+				matches := resourceRefPattern.FindAllStringSubmatch(envValue, -1)
+				for _, match := range matches {
+					if len(match) >= 3 {
+						resourceKey := match[1]
+						outputKey := match[2]
+
+						// Check if the referenced output is available
+						if outputs, exists := availableOutputs[resourceKey]; exists {
+							if outputs[outputKey] {
+								envMappings = append(envMappings, scorev1b1.EnvMapping{
+									Name: envName,
+									From: scorev1b1.FromBindingOutput{
+										ClaimKey:  resourceKey,
+										OutputKey: outputKey,
+									},
+								})
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Add default mappings for available outputs that weren't explicitly referenced
+	for _, claim := range claims {
+		if claim.Status.OutputsAvailable {
+			// Create default environment variable for URI if available
+			if claim.Status.Outputs.URI != nil {
+				envVar := fmt.Sprintf("%s_URI", strings.ToUpper(claim.Spec.Key))
+				// Only add if not already mapped
+				found := false
+				for _, mapping := range envMappings {
+					if mapping.From.ClaimKey == claim.Spec.Key && mapping.From.OutputKey == outputKeyURI {
+						found = true
+						break
+					}
+				}
+				if !found {
+					envMappings = append(envMappings, scorev1b1.EnvMapping{
+						Name: envVar,
+						From: scorev1b1.FromBindingOutput{
+							ClaimKey:  claim.Spec.Key,
+							OutputKey: outputKeyURI,
+						},
+					})
+				}
+			}
+		}
+	}
+
+	return envMappings
+}
+
+// generateVolumeProjections generates volume projections from container file specifications that reference secrets/configmaps
+func generateVolumeProjections(workload *scorev1b1.Workload, claims []scorev1b1.ResourceClaim) []scorev1b1.VolumeProjection {
+	var volumeProjections []scorev1b1.VolumeProjection
+
+	// Create a map of available secret/configmap outputs
+	availableRefs := make(map[string][]string)
+	for _, claim := range claims {
+		if claim.Status.OutputsAvailable {
+			var refs []string
+			if claim.Status.Outputs.SecretRef != nil {
+				refs = append(refs, "secretRef")
+			}
+			if claim.Status.Outputs.ConfigMapRef != nil {
+				refs = append(refs, "configMapRef")
+			}
+			if len(refs) > 0 {
+				availableRefs[claim.Spec.Key] = refs
+			}
+		}
+	}
+
+	// Scan container files for resource references that could be volumes
+	for _, container := range workload.Spec.Containers {
+		if container.Files != nil {
+			for _, file := range container.Files {
+				if file.Source != nil {
+					// Check if source references a resource output
+					resourceRefPattern := regexp.MustCompile(`\$\{resources\.([^.]+)\.outputs\.([^}]+)\}`)
+					matches := resourceRefPattern.FindStringSubmatch(file.Source.URI)
+
+					if len(matches) >= 3 {
+						resourceKey := matches[1]
+						outputKey := matches[2]
+
+						// Check if the referenced output is available and is a volume-like reference
+						if refs, exists := availableRefs[resourceKey]; exists {
+							for _, ref := range refs {
+								if ref == outputKey {
+									volumeProjections = append(volumeProjections, scorev1b1.VolumeProjection{
+										Name: fmt.Sprintf("%s-%s", resourceKey, outputKey),
+										From: &scorev1b1.FromBindingOutput{
+											ClaimKey:  resourceKey,
+											OutputKey: outputKey,
+										},
+									})
+									break
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return volumeProjections
+}
+
+// generateFileProjections generates file projections from container file specifications
+func generateFileProjections(workload *scorev1b1.Workload, claims []scorev1b1.ResourceClaim) []scorev1b1.FileProjection {
+	var fileProjections []scorev1b1.FileProjection
+
+	// Create a map of available cert outputs
+	availableCerts := make(map[string]bool)
+	for _, claim := range claims {
+		if claim.Status.OutputsAvailable && claim.Status.Outputs.Cert != nil {
+			availableCerts[claim.Spec.Key] = true
+		}
+	}
+
+	// Scan container files for resource references
+	for _, container := range workload.Spec.Containers {
+		if container.Files != nil {
+			for _, file := range container.Files {
+				if file.Source != nil {
+					// Check if source references a certificate resource
+					resourceRefPattern := regexp.MustCompile(`\$\{resources\.([^.]+)\.outputs\.cert\}`)
+					matches := resourceRefPattern.FindStringSubmatch(file.Source.URI)
+
+					if len(matches) >= 2 {
+						resourceKey := matches[1]
+
+						// Check if the referenced cert output is available
+						if availableCerts[resourceKey] {
+							fileProjections = append(fileProjections, scorev1b1.FileProjection{
+								Path: file.Target,
+								From: &scorev1b1.FromBindingOutput{
+									ClaimKey:  resourceKey,
+									OutputKey: "cert",
+								},
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return fileProjections
+}
+
+// validateProjectionRequirements checks if all required resource outputs are available for projection
+func validateProjectionRequirements(workload *scorev1b1.Workload, claims []scorev1b1.ResourceClaim) error {
+	// Create a map of available outputs
+	availableOutputs := make(map[string]map[string]bool)
+	for _, claim := range claims {
+		if claim.Status.OutputsAvailable {
+			outputs := make(map[string]bool)
+			if claim.Status.Outputs.URI != nil {
+				outputs[outputKeyURI] = true
+			}
+			if claim.Status.Outputs.SecretRef != nil {
+				outputs["secretRef"] = true
+			}
+			if claim.Status.Outputs.ConfigMapRef != nil {
+				outputs["configMapRef"] = true
+			}
+			if claim.Status.Outputs.Image != nil {
+				outputs["image"] = true
+			}
+			if claim.Status.Outputs.Cert != nil {
+				outputs["cert"] = true
+			}
+			availableOutputs[claim.Spec.Key] = outputs
+		}
+	}
+
+	// Regular expression to match ${resources.<key>.outputs.<name>} patterns
+	resourceRefPattern := regexp.MustCompile(`\$\{resources\.([^.]+)\.outputs\.([^}]+)\}`)
+
+	var missingOutputs []string
+
+	// Check container environment variables
+	for containerName, container := range workload.Spec.Containers {
+		if container.Variables != nil {
+			for envName, envValue := range container.Variables {
+				matches := resourceRefPattern.FindAllStringSubmatch(envValue, -1)
+				for _, match := range matches {
+					if len(match) >= 3 {
+						resourceKey := match[1]
+						outputKey := match[2]
+
+						// Check if the referenced output is available
+						if outputs, exists := availableOutputs[resourceKey]; !exists {
+							missingOutputs = append(missingOutputs, fmt.Sprintf("container[%s].env[%s]: resource '%s' has no outputs available", containerName, envName, resourceKey))
+						} else if !outputs[outputKey] {
+							missingOutputs = append(missingOutputs, fmt.Sprintf("container[%s].env[%s]: resource '%s' missing output '%s'", containerName, envName, resourceKey, outputKey))
+						}
+					}
+				}
+			}
+		}
+
+		// Container volumes are handled via Files with source references
+		// No separate volumes field exists in ContainerSpec
+
+		// Check container files
+		if container.Files != nil {
+			for i, file := range container.Files {
+				if file.Source != nil {
+					matches := resourceRefPattern.FindStringSubmatch(file.Source.URI)
+					if len(matches) >= 3 {
+						resourceKey := matches[1]
+						outputKey := matches[2]
+
+						// Check if the referenced output is available
+						if outputs, exists := availableOutputs[resourceKey]; !exists {
+							missingOutputs = append(missingOutputs, fmt.Sprintf("container[%s].files[%d]: resource '%s' has no outputs available", containerName, i, resourceKey))
+						} else if !outputs[outputKey] {
+							missingOutputs = append(missingOutputs, fmt.Sprintf("container[%s].files[%d]: resource '%s' missing output '%s'", containerName, i, resourceKey, outputKey))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if len(missingOutputs) > 0 {
+		return fmt.Errorf("missing required outputs for projection: %s", strings.Join(missingOutputs, "; "))
+	}
+
+	return nil
 }
 
 // buildPlanBindings creates the binding requirements for the runtime

--- a/internal/reconcile/plan_test.go
+++ b/internal/reconcile/plan_test.go
@@ -1,0 +1,663 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/selection"
+)
+
+func TestValidateProjectionRequirements(t *testing.T) {
+	tests := []struct {
+		name        string
+		workload    *scorev1b1.Workload
+		claims      []scorev1b1.ResourceClaim
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid projection - all outputs available",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Variables: map[string]string{
+								"DATABASE_URL": "${resources.db.outputs.uri}",
+								"CACHE_URL":    "${resources.cache.outputs.uri}",
+							},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "db"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							URI: ptr.To("postgres://localhost/db"),
+						},
+					},
+				},
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "cache"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							URI: ptr.To("redis://localhost/0"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "missing resource outputs",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Variables: map[string]string{
+								"DATABASE_URL": "${resources.db.outputs.uri}",
+							},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec:   scorev1b1.ResourceClaimSpec{Key: "db"},
+					Status: scorev1b1.ResourceClaimStatus{OutputsAvailable: false},
+				},
+			},
+			expectError: true,
+			errorMsg:    "resource 'db' has no outputs available",
+		},
+		{
+			name: "missing specific output",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Variables: map[string]string{
+								"DATABASE_URL": "${resources.db.outputs.uri}",
+							},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "db"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							SecretRef: &scorev1b1.LocalObjectReference{Name: "db-secret"},
+							// URI is missing
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "missing output 'uri'",
+		},
+		{
+			name: "volume source references",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Files: []scorev1b1.FileSpec{
+								{
+									Target: "/data",
+									Source: &scorev1b1.FileSourceSpec{
+										URI: "${resources.storage.outputs.secretRef}",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "storage"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							SecretRef: &scorev1b1.LocalObjectReference{Name: "storage-secret"},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "file source references",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Files: []scorev1b1.FileSpec{
+								{
+									Target: "/etc/ssl/cert.pem",
+									Source: &scorev1b1.FileSourceSpec{
+										URI: "${resources.tls.outputs.cert}",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "tls"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							Cert: &scorev1b1.CertificateOutput{
+								Data: map[string][]byte{
+									"cert.pem": []byte("certificate-data"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "no resource references - should pass",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Variables: map[string]string{
+								"STATIC_VAR": "static-value",
+							},
+						},
+					},
+				},
+			},
+			claims:      []scorev1b1.ResourceClaim{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProjectionRequirements(tt.workload, tt.claims)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+				if tt.errorMsg != "" && !contains(err.Error(), tt.errorMsg) {
+					t.Errorf("expected error to contain %q, got %q", tt.errorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildProjection(t *testing.T) {
+	tests := []struct {
+		name       string
+		workload   *scorev1b1.Workload
+		claims     []scorev1b1.ResourceClaim
+		expectEnv  int
+		expectVol  int
+		expectFile int
+	}{
+		{
+			name: "environment variable mappings",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Variables: map[string]string{
+								"DATABASE_URL": "${resources.db.outputs.uri}",
+								"API_KEY":      "${resources.auth.outputs.secretRef}",
+								"STATIC":       "value",
+							},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "db"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							URI: ptr.To("postgres://localhost/db"),
+						},
+					},
+				},
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "auth"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							SecretRef: &scorev1b1.LocalObjectReference{Name: "auth-secret"},
+						},
+					},
+				},
+			},
+			expectEnv: 2, // DATABASE_URL and API_KEY mappings
+		},
+		{
+			name: "volume projections",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Files: []scorev1b1.FileSpec{
+								{
+									Target: "/config",
+									Source: &scorev1b1.FileSourceSpec{
+										URI: "${resources.config.outputs.configMapRef}",
+									},
+								},
+								{
+									Target: "/secrets",
+									Source: &scorev1b1.FileSourceSpec{
+										URI: "${resources.auth.outputs.secretRef}",
+									},
+								},
+								{
+									Target: "/static",
+									Source: &scorev1b1.FileSourceSpec{
+										URI: "/host/path",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "config"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							ConfigMapRef: &scorev1b1.LocalObjectReference{Name: "config-map"},
+						},
+					},
+				},
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "auth"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							SecretRef: &scorev1b1.LocalObjectReference{Name: "auth-secret"},
+						},
+					},
+				},
+			},
+			expectVol: 2, // config and auth volume mappings
+		},
+		{
+			name: "file projections",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Files: []scorev1b1.FileSpec{
+								{
+									Target: "/etc/ssl/ca.crt",
+									Source: &scorev1b1.FileSourceSpec{
+										URI: "${resources.tls.outputs.cert}",
+									},
+								},
+								{
+									Target:  "/config/app.yaml",
+									Content: ptr.To("static content"),
+								},
+							},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "tls"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							Cert: &scorev1b1.CertificateOutput{
+								SecretName: ptr.To("tls-secret"),
+							},
+						},
+					},
+				},
+			},
+			expectFile: 1, // Only the cert file projection
+		},
+		{
+			name: "default URI mapping when no explicit references",
+			workload: &scorev1b1.Workload{
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Variables: map[string]string{
+								"PORT": "8080",
+							},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "database"},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							URI: ptr.To("postgres://localhost/db"),
+						},
+					},
+				},
+			},
+			expectEnv: 1, // Default DATABASE_URI mapping
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projection := buildProjection(tt.workload, tt.claims)
+
+			if len(projection.Env) != tt.expectEnv {
+				t.Errorf("expected %d env mappings, got %d", tt.expectEnv, len(projection.Env))
+			}
+
+			if len(projection.Volumes) != tt.expectVol {
+				t.Errorf("expected %d volume projections, got %d", tt.expectVol, len(projection.Volumes))
+			}
+
+			if len(projection.Files) != tt.expectFile {
+				t.Errorf("expected %d file projections, got %d", tt.expectFile, len(projection.Files))
+			}
+
+			// Verify specific mappings for the first test
+			if tt.name == "environment variable mappings" && len(projection.Env) >= 2 {
+				foundDB := false
+				foundAuth := false
+				for _, mapping := range projection.Env {
+					if mapping.Name == "DATABASE_URL" && mapping.From.ClaimKey == "db" && mapping.From.OutputKey == "uri" {
+						foundDB = true
+					}
+					if mapping.Name == "API_KEY" && mapping.From.ClaimKey == "auth" && mapping.From.OutputKey == "secretRef" {
+						foundAuth = true
+					}
+				}
+				if !foundDB {
+					t.Error("expected DATABASE_URL mapping not found")
+				}
+				if !foundAuth {
+					t.Error("expected API_KEY mapping not found")
+				}
+			}
+		})
+	}
+}
+
+func TestWorkloadPlanSpecEqual(t *testing.T) {
+	baseSpec := scorev1b1.WorkloadPlanSpec{
+		WorkloadRef: scorev1b1.WorkloadPlanWorkloadRef{
+			Name:      "test-app",
+			Namespace: "default",
+		},
+		ObservedWorkloadGeneration: 1,
+		RuntimeClass:               "kubernetes",
+		Template: &scorev1b1.TemplateSpec{
+			Kind: "manifests",
+			Ref:  "registry.example.com/templates/web@sha256:abc123",
+		},
+		Values: &runtime.RawExtension{
+			Raw: []byte(`{"replicas": 3}`),
+		},
+		Projection: scorev1b1.WorkloadProjection{
+			Env: []scorev1b1.EnvMapping{
+				{
+					Name: "DATABASE_URL",
+					From: scorev1b1.FromBindingOutput{
+						ClaimKey:  "db",
+						OutputKey: "uri",
+					},
+				},
+			},
+		},
+		Bindings: []scorev1b1.PlanBinding{
+			{
+				Key:  "db",
+				Type: "postgres",
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		a, b     scorev1b1.WorkloadPlanSpec
+		expected bool
+	}{
+		{
+			name:     "identical specs",
+			a:        baseSpec,
+			b:        baseSpec,
+			expected: true,
+		},
+		{
+			name: "different workload ref",
+			a:    baseSpec,
+			b: func() scorev1b1.WorkloadPlanSpec {
+				spec := baseSpec
+				spec.WorkloadRef.Name = "different-app"
+				return spec
+			}(),
+			expected: false,
+		},
+		{
+			name: "different generation",
+			a:    baseSpec,
+			b: func() scorev1b1.WorkloadPlanSpec {
+				spec := baseSpec
+				spec.ObservedWorkloadGeneration = 2
+				return spec
+			}(),
+			expected: false,
+		},
+		{
+			name: "different runtime class",
+			a:    baseSpec,
+			b: func() scorev1b1.WorkloadPlanSpec {
+				spec := baseSpec
+				spec.RuntimeClass = "ecs"
+				return spec
+			}(),
+			expected: false,
+		},
+		{
+			name: "different env mappings count",
+			a:    baseSpec,
+			b: func() scorev1b1.WorkloadPlanSpec {
+				spec := baseSpec
+				spec.Projection.Env = []scorev1b1.EnvMapping{}
+				return spec
+			}(),
+			expected: false,
+		},
+		{
+			name: "different bindings count",
+			a:    baseSpec,
+			b: func() scorev1b1.WorkloadPlanSpec {
+				spec := baseSpec
+				spec.Bindings = []scorev1b1.PlanBinding{}
+				return spec
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := workloadPlanSpecEqual(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIntegrationWithSelectedBackend(t *testing.T) {
+	// This test demonstrates the full integration with SelectedBackend
+	selectedBackend := &selection.SelectedBackend{
+		BackendID:    "k8s-web-standard",
+		RuntimeClass: "kubernetes",
+		Template: scorev1b1.TemplateSpec{
+			Kind: "manifests",
+			Ref:  "registry.example.com/templates/web@sha256:abc123",
+			Values: &runtime.RawExtension{
+				Raw: []byte(`{"replicas": 2, "resources": {"cpu": "100m"}}`),
+			},
+		},
+		Priority: 100,
+		Version:  "1.0.0",
+	}
+
+	workload := &scorev1b1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "default",
+		},
+		Spec: scorev1b1.WorkloadSpec{
+			Containers: map[string]scorev1b1.ContainerSpec{
+				"web": {
+					Image: "nginx:1.20",
+					Variables: map[string]string{
+						"DATABASE_URL": "${resources.db.outputs.uri}",
+					},
+				},
+			},
+		},
+	}
+
+	claims := []scorev1b1.ResourceClaim{
+		{
+			Spec: scorev1b1.ResourceClaimSpec{
+				Key:  "db",
+				Type: "postgres",
+			},
+			Status: scorev1b1.ResourceClaimStatus{
+				OutputsAvailable: true,
+				Outputs: scorev1b1.ResourceClaimOutputs{
+					URI: ptr.To("postgres://prod-db:5432/myapp"),
+				},
+			},
+		},
+	}
+
+	// Test values composition
+	values, err := composeValues(selectedBackend.Template.Values, workload, claims)
+	if err != nil {
+		t.Fatalf("failed to compose values: %v", err)
+	}
+
+	var composedValues map[string]interface{}
+	if err := json.Unmarshal(values.Raw, &composedValues); err != nil {
+		t.Fatalf("failed to unmarshal composed values: %v", err)
+	}
+
+	// Verify defaults were included
+	if composedValues["replicas"] != float64(2) {
+		t.Errorf("expected replicas=2, got %v", composedValues["replicas"])
+	}
+
+	// Verify workload normalization
+	containers, ok := composedValues["containers"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected containers in composed values")
+	}
+	webContainer, ok := containers["web"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected web container in composed values")
+	}
+	if webContainer["image"] != "nginx:1.20" {
+		t.Errorf("expected nginx:1.20, got %v", webContainer["image"])
+	}
+
+	// Verify resource outputs
+	resources, ok := composedValues["resources"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected resources in composed values")
+	}
+	dbResource, ok := resources["db"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected db resource in composed values")
+	}
+	outputs, ok := dbResource["outputs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected outputs in db resource")
+	}
+	if outputs["uri"] != "postgres://prod-db:5432/myapp" {
+		t.Errorf("expected postgres URI, got %v", outputs["uri"])
+	}
+
+	// Test projection building
+	projection := buildProjection(workload, claims)
+	if len(projection.Env) == 0 {
+		t.Error("expected environment variable mappings")
+	}
+
+	foundDBMapping := false
+	for _, mapping := range projection.Env {
+		if mapping.Name == "DATABASE_URL" && mapping.From.ClaimKey == "db" && mapping.From.OutputKey == "uri" {
+			foundDBMapping = true
+			break
+		}
+	}
+	if !foundDBMapping {
+		t.Error("expected DATABASE_URL mapping not found")
+	}
+}
+
+// Helper function to check if string contains substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsInMiddle(s, substr)))
+}
+
+func containsInMiddle(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/reconcile/values.go
+++ b/internal/reconcile/values.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+)
+
+// composeValues implements the ADR-0003 values composition rule:
+// defaults ⊕ normalize(Workload) ⊕ outputs
+// where right-hand values win in case of conflicts.
+func composeValues(
+	defaults *runtime.RawExtension,
+	workload *scorev1b1.Workload,
+	claims []scorev1b1.ResourceClaim,
+) (*runtime.RawExtension, error) {
+	// Step 1: Extract defaults as a map
+	defaultsMap := make(map[string]interface{})
+	if defaults != nil && defaults.Raw != nil {
+		if err := json.Unmarshal(defaults.Raw, &defaultsMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal defaults: %w", err)
+		}
+	}
+
+	// Step 2: Normalize workload to template values
+	normalizedMap := normalizeWorkload(workload)
+
+	// Step 3: Extract outputs from resource claims
+	outputsMap := extractOutputs(claims)
+
+	// Step 4: Merge maps with right-hand precedence
+	result := mergeMaps(defaultsMap, normalizedMap, outputsMap)
+
+	// Convert back to RawExtension
+	resultBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal composed values: %w", err)
+	}
+
+	return &runtime.RawExtension{Raw: resultBytes}, nil
+}
+
+// normalizeWorkload converts a Workload specification into template values
+func normalizeWorkload(workload *scorev1b1.Workload) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	// Normalize containers
+	if len(workload.Spec.Containers) > 0 {
+		containers := make(map[string]interface{})
+		for name, container := range workload.Spec.Containers {
+			containerMap := map[string]interface{}{
+				"image": container.Image,
+			}
+
+			if len(container.Command) > 0 {
+				containerMap["command"] = container.Command
+			}
+			if len(container.Args) > 0 {
+				containerMap["args"] = container.Args
+			}
+			if len(container.Variables) > 0 {
+				containerMap["env"] = container.Variables
+			}
+			if len(container.Files) > 0 {
+				containerMap["files"] = container.Files
+			}
+
+			containers[name] = containerMap
+		}
+		result["containers"] = containers
+	}
+
+	// Normalize service
+	if workload.Spec.Service != nil {
+		service := make(map[string]interface{})
+		if len(workload.Spec.Service.Ports) > 0 {
+			ports := make([]map[string]interface{}, 0, len(workload.Spec.Service.Ports))
+			for _, port := range workload.Spec.Service.Ports {
+				portMap := map[string]interface{}{
+					"port": port.Port,
+				}
+				if port.Protocol != "" {
+					portMap["protocol"] = port.Protocol
+				}
+				if port.TargetPort != nil {
+					portMap["targetPort"] = *port.TargetPort
+				}
+				ports = append(ports, portMap)
+			}
+			service["ports"] = ports
+		}
+		result["service"] = service
+	}
+
+	// Add workload metadata
+	result["name"] = workload.Name
+	result["namespace"] = workload.Namespace
+	if workload.Labels != nil {
+		result["labels"] = workload.Labels
+	}
+	if workload.Annotations != nil {
+		result["annotations"] = workload.Annotations
+	}
+
+	return result
+}
+
+// extractOutputs extracts outputs from ResourceClaim status and organizes them by resource key
+func extractOutputs(claims []scorev1b1.ResourceClaim) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	if len(claims) == 0 {
+		return result
+	}
+
+	resources := make(map[string]interface{})
+
+	for _, claim := range claims {
+		if !claim.Status.OutputsAvailable {
+			continue
+		}
+
+		resourceOutputs := make(map[string]interface{})
+
+		if claim.Status.Outputs.SecretRef != nil {
+			resourceOutputs["secretRef"] = map[string]interface{}{
+				"name": claim.Status.Outputs.SecretRef.Name,
+			}
+		}
+
+		if claim.Status.Outputs.ConfigMapRef != nil {
+			resourceOutputs["configMapRef"] = map[string]interface{}{
+				"name": claim.Status.Outputs.ConfigMapRef.Name,
+			}
+		}
+
+		if claim.Status.Outputs.URI != nil {
+			resourceOutputs["uri"] = *claim.Status.Outputs.URI
+		}
+
+		if claim.Status.Outputs.Image != nil {
+			resourceOutputs["image"] = *claim.Status.Outputs.Image
+		}
+
+		if claim.Status.Outputs.Cert != nil {
+			certMap := make(map[string]interface{})
+			if claim.Status.Outputs.Cert.SecretName != nil {
+				certMap["secretName"] = *claim.Status.Outputs.Cert.SecretName
+			}
+			if claim.Status.Outputs.Cert.Data != nil {
+				certMap["data"] = claim.Status.Outputs.Cert.Data
+			}
+			resourceOutputs["cert"] = certMap
+		}
+
+		if len(resourceOutputs) > 0 {
+			resources[claim.Spec.Key] = map[string]interface{}{
+				"outputs": resourceOutputs,
+			}
+		}
+	}
+
+	if len(resources) > 0 {
+		result["resources"] = resources
+	}
+
+	return result
+}
+
+// mergeMaps merges multiple maps with right-hand precedence
+func mergeMaps(maps ...map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	for _, m := range maps {
+		for key, value := range m {
+			// Deep merge for nested maps
+			if existing, exists := result[key]; exists {
+				if existingMap, ok := existing.(map[string]interface{}); ok {
+					if valueMap, ok := value.(map[string]interface{}); ok {
+						result[key] = mergeMaps(existingMap, valueMap)
+						continue
+					}
+				}
+			}
+			// For non-map values or when key doesn't exist, right-hand wins
+			result[key] = value
+		}
+	}
+
+	return result
+}

--- a/internal/reconcile/values_test.go
+++ b/internal/reconcile/values_test.go
@@ -1,0 +1,665 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+)
+
+func TestComposeValues(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaults    *runtime.RawExtension
+		workload    *scorev1b1.Workload
+		claims      []scorev1b1.ResourceClaim
+		expected    map[string]interface{}
+		expectError bool
+	}{
+		{
+			name: "basic composition with all sources",
+			defaults: &runtime.RawExtension{
+				Raw: []byte(`{"replicas": 1, "resources": {"cpu": "100m"}}`),
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "default",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"main": {
+							Image: "nginx:latest",
+							Variables: map[string]string{
+								"PORT": "8080",
+							},
+						},
+					},
+					Service: &scorev1b1.ServiceSpec{
+						Ports: []scorev1b1.ServicePort{
+							{Port: 80},
+						},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{
+						Key: "database",
+					},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							URI: ptr.To("postgres://localhost:5432/testdb"),
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"replicas": float64(1), // JSON numbers are float64
+				"resources": map[string]interface{}{
+					"cpu": "100m",
+					"database": map[string]interface{}{
+						"outputs": map[string]interface{}{
+							"uri": "postgres://localhost:5432/testdb",
+						},
+					},
+				},
+				"name":      "test-app",
+				"namespace": "default",
+				"containers": map[string]interface{}{
+					"main": map[string]interface{}{
+						"image": "nginx:latest",
+						"env": map[string]interface{}{
+							"PORT": "8080",
+						},
+					},
+				},
+				"service": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"port": float64(80),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "nil defaults",
+			defaults: nil,
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-app",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"main": {Image: "nginx"},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{},
+			expected: map[string]interface{}{
+				"name":      "test-app",
+				"namespace": "",
+				"containers": map[string]interface{}{
+					"main": map[string]interface{}{
+						"image": "nginx",
+					},
+				},
+			},
+		},
+		{
+			name: "empty defaults raw",
+			defaults: &runtime.RawExtension{
+				Raw: nil,
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-app",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"main": {Image: "nginx"},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{},
+			expected: map[string]interface{}{
+				"name":      "test-app",
+				"namespace": "",
+				"containers": map[string]interface{}{
+					"main": map[string]interface{}{
+						"image": "nginx",
+					},
+				},
+			},
+		},
+		{
+			name: "right-hand precedence - outputs override defaults",
+			defaults: &runtime.RawExtension{
+				Raw: []byte(`{"database_url": "default://localhost"}`),
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-app",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"main": {Image: "nginx"},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{
+						Key: "db",
+					},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							URI: ptr.To("postgres://prod:5432/mydb"),
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"database_url": "default://localhost", // from defaults
+				"name":         "test-app",            // from workload
+				"namespace":    "",                    // from workload
+				"containers": map[string]interface{}{
+					"main": map[string]interface{}{
+						"image": "nginx",
+					},
+				},
+				"resources": map[string]interface{}{
+					"db": map[string]interface{}{
+						"outputs": map[string]interface{}{
+							"uri": "postgres://prod:5432/mydb", // from outputs
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "deep merge of nested maps",
+			defaults: &runtime.RawExtension{
+				Raw: []byte(`{"resources": {"cpu": "100m", "memory": "128Mi"}}`),
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-app",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"main": {Image: "nginx"},
+					},
+				},
+			},
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{
+						Key: "db",
+					},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							URI: ptr.To("postgres://localhost/db"),
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"name":      "test-app",
+				"namespace": "",
+				"containers": map[string]interface{}{
+					"main": map[string]interface{}{
+						"image": "nginx",
+					},
+				},
+				"resources": map[string]interface{}{
+					"cpu":    "100m",  // from defaults
+					"memory": "128Mi", // from defaults
+					"db": map[string]interface{}{ // from outputs
+						"outputs": map[string]interface{}{
+							"uri": "postgres://localhost/db",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid defaults JSON",
+			defaults: &runtime.RawExtension{
+				Raw: []byte(`{invalid json`),
+			},
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-app",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"main": {Image: "nginx"},
+					},
+				},
+			},
+			claims:      []scorev1b1.ResourceClaim{},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := composeValues(tt.defaults, tt.workload, tt.claims)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result == nil || result.Raw == nil {
+				t.Fatalf("expected non-nil result")
+			}
+
+			var actual map[string]interface{}
+			if err := json.Unmarshal(result.Raw, &actual); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+
+			if !equalMaps(actual, tt.expected) {
+				t.Errorf("expected %+v, got %+v", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestNormalizeWorkload(t *testing.T) {
+	tests := []struct {
+		name     string
+		workload *scorev1b1.Workload
+		expected map[string]interface{}
+	}{
+		{
+			name: "complete workload",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"app": "test",
+					},
+					Annotations: map[string]string{
+						"version": "1.0",
+					},
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"main": {
+							Image:   "nginx:1.20",
+							Command: []string{"/bin/sh"},
+							Args:    []string{"-c", "nginx"},
+							Variables: map[string]string{
+								"ENV": "prod",
+							},
+						},
+						"sidecar": {
+							Image: "busybox",
+						},
+					},
+					Service: &scorev1b1.ServiceSpec{
+						Ports: []scorev1b1.ServicePort{
+							{
+								Port:     80,
+								Protocol: "TCP",
+							},
+							{
+								Port: 443,
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"name":      "test-app",
+				"namespace": "test-ns",
+				"labels": map[string]interface{}{
+					"app": "test",
+				},
+				"annotations": map[string]interface{}{
+					"version": "1.0",
+				},
+				"containers": map[string]interface{}{
+					"main": map[string]interface{}{
+						"image":   "nginx:1.20",
+						"command": []interface{}{"/bin/sh"},
+						"args":    []interface{}{"-c", "nginx"},
+						"env": map[string]interface{}{
+							"ENV": "prod",
+						},
+					},
+					"sidecar": map[string]interface{}{
+						"image": "busybox",
+					},
+				},
+				"service": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"port":     80,
+							"protocol": "TCP",
+						},
+						map[string]interface{}{
+							"port": 443,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "minimal workload",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "minimal-app",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Containers: map[string]scorev1b1.ContainerSpec{
+						"app": {
+							Image: "hello-world",
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"name":      "minimal-app",
+				"namespace": "",
+				"containers": map[string]interface{}{
+					"app": map[string]interface{}{
+						"image": "hello-world",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeWorkload(tt.workload)
+
+			// JSON経由で型の一貫性を保証
+			resultJSON, err := json.Marshal(result)
+			if err != nil {
+				t.Fatalf("failed to marshal result: %v", err)
+			}
+
+			expectedJSON, err := json.Marshal(tt.expected)
+			if err != nil {
+				t.Fatalf("failed to marshal expected: %v", err)
+			}
+
+			var resultNormalized, expectedNormalized map[string]interface{}
+			if err := json.Unmarshal(resultJSON, &resultNormalized); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+			if err := json.Unmarshal(expectedJSON, &expectedNormalized); err != nil {
+				t.Fatalf("failed to unmarshal expected: %v", err)
+			}
+
+			if !equalMaps(resultNormalized, expectedNormalized) {
+				t.Errorf("expected %+v, got %+v", expectedNormalized, resultNormalized)
+			}
+		})
+	}
+}
+
+func TestExtractOutputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   []scorev1b1.ResourceClaim
+		expected map[string]interface{}
+	}{
+		{
+			name: "multiple claims with different outputs",
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{
+						Key: "database",
+					},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							URI: ptr.To("postgres://localhost:5432/db"),
+							SecretRef: &scorev1b1.LocalObjectReference{
+								Name: "db-secret",
+							},
+						},
+					},
+				},
+				{
+					Spec: scorev1b1.ResourceClaimSpec{
+						Key: "cache",
+					},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: true,
+						Outputs: scorev1b1.ResourceClaimOutputs{
+							URI: ptr.To("redis://localhost:6379"),
+						},
+					},
+				},
+				{
+					Spec: scorev1b1.ResourceClaimSpec{
+						Key: "storage",
+					},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: false, // Not available yet
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"resources": map[string]interface{}{
+					"database": map[string]interface{}{
+						"outputs": map[string]interface{}{
+							"uri": "postgres://localhost:5432/db",
+							"secretRef": map[string]interface{}{
+								"name": "db-secret",
+							},
+						},
+					},
+					"cache": map[string]interface{}{
+						"outputs": map[string]interface{}{
+							"uri": "redis://localhost:6379",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "empty claims",
+			claims:   []scorev1b1.ResourceClaim{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "claims with no available outputs",
+			claims: []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{
+						Key: "pending",
+					},
+					Status: scorev1b1.ResourceClaimStatus{
+						OutputsAvailable: false,
+					},
+				},
+			},
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractOutputs(tt.claims)
+
+			if !equalMaps(result, tt.expected) {
+				t.Errorf("expected %+v, got %+v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMergeMaps(t *testing.T) {
+	tests := []struct {
+		name     string
+		maps     []map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name: "right-hand precedence",
+			maps: []map[string]interface{}{
+				{"a": 1, "b": 2},
+				{"b": 3, "c": 4},
+				{"c": 5, "d": 6},
+			},
+			expected: map[string]interface{}{
+				"a": 1, // from first
+				"b": 3, // from second (overrides first)
+				"c": 5, // from third (overrides second)
+				"d": 6, // from third
+			},
+		},
+		{
+			name: "deep merge of nested maps",
+			maps: []map[string]interface{}{
+				{
+					"config": map[string]interface{}{
+						"database": map[string]interface{}{
+							"host": "localhost",
+							"port": 5432,
+						},
+						"cache": map[string]interface{}{
+							"ttl": 300,
+						},
+					},
+				},
+				{
+					"config": map[string]interface{}{
+						"database": map[string]interface{}{
+							"port": 5433, // overrides
+							"ssl":  true, // adds new
+						},
+						"logging": map[string]interface{}{
+							"level": "info",
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"config": map[string]interface{}{
+					"database": map[string]interface{}{
+						"host": "localhost", // from first
+						"port": 5433,        // from second (overrides)
+						"ssl":  true,        // from second (new)
+					},
+					"cache": map[string]interface{}{
+						"ttl": 300, // from first
+					},
+					"logging": map[string]interface{}{
+						"level": "info", // from second
+					},
+				},
+			},
+		},
+		{
+			name: "non-map values override completely",
+			maps: []map[string]interface{}{
+				{
+					"value": map[string]interface{}{
+						"nested": "original",
+					},
+				},
+				{
+					"value": "replacement", // completely replaces the map
+				},
+			},
+			expected: map[string]interface{}{
+				"value": "replacement",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeMaps(tt.maps...)
+
+			if !equalMaps(result, tt.expected) {
+				t.Errorf("expected %+v, got %+v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// Helper function to compare maps deeply
+func equalMaps(a, b map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for key, valueA := range a {
+		valueB, exists := b[key]
+		if !exists {
+			return false
+		}
+
+		if !equalValues(valueA, valueB) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Helper function to compare values deeply
+func equalValues(a, b interface{}) bool {
+	switch aVal := a.(type) {
+	case map[string]interface{}:
+		bVal, ok := b.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		return equalMaps(aVal, bVal)
+	case []interface{}:
+		bVal, ok := b.([]interface{})
+		if !ok || len(aVal) != len(bVal) {
+			return false
+		}
+		for i, itemA := range aVal {
+			if !equalValues(itemA, bVal[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return a == b
+	}
+}


### PR DESCRIPTION
Enable runtime controllers to materialize workloads via templates by enhancing WorkloadPlan generation with template references and values composition following ADR-0003 specification.

Template values are composed with proper precedence: defaults ⊕ normalize(Workload) ⊕ outputs. Projection rules are generated for environment variables, volumes, and files based on Score placeholders in workload specifications. Backend selection now uses SelectedBackend struct to provide complete template metadata to WorkloadPlan.

This completes the "Workload → ResourceClaim → WorkloadPlan" pipeline enabling runtime-agnostic UX where users only need to define Workload resources.