### PR TITLE
Implement template-based endpoint derivation for WorkloadPlan

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
 	"github.com/cappyzawa/score-orchestrator/internal/config"
 	"github.com/cappyzawa/score-orchestrator/internal/controller"
+	"github.com/cappyzawa/score-orchestrator/internal/endpoint"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -200,10 +201,11 @@ func main() {
 	configLoader := config.NewConfigMapLoader(clientset, config.DefaultLoaderOptions())
 
 	if err := (&controller.WorkloadReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		Recorder:     mgr.GetEventRecorderFor("workload-controller"),
-		ConfigLoader: configLoader,
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		Recorder:        mgr.GetEventRecorderFor("workload-controller"),
+		ConfigLoader:    configLoader,
+		EndpointDeriver: endpoint.NewEndpointDeriver(mgr.GetClient()),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Workload")
 		os.Exit(1)

--- a/config/samples/score_v1b1_workload.yaml
+++ b/config/samples/score_v1b1_workload.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kbinit
     app.kubernetes.io/managed-by: kustomize
+    environment: development
+    team: backend
   name: workload-sample
   namespace: score-system
 spec:
@@ -75,6 +77,8 @@ metadata:
   namespace: test-dev
   labels:
     app: web-app
+    environment: development
+    team: backend
 spec:
   containers:
     app:
@@ -99,6 +103,7 @@ metadata:
   namespace: test-prod
   labels:
     app: web-app
+    environment: production
   annotations:
     score.dev/requirements: "monitoring"
 spec:
@@ -141,6 +146,9 @@ kind: Workload
 metadata:
   name: app-with-db
   namespace: test-dev
+  labels:
+    environment: development
+    team: backend
 spec:
   containers:
     app:

--- a/internal/endpoint/derivation.go
+++ b/internal/endpoint/derivation.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EndpointDeriver derives endpoints from WorkloadPlan templates and service configurations
+type EndpointDeriver struct {
+	client client.Client
+}
+
+// NewEndpointDeriver creates a new endpoint deriver
+func NewEndpointDeriver(c client.Client) *EndpointDeriver {
+	return &EndpointDeriver{
+		client: c,
+	}
+}
+
+// DeriveEndpoint derives the canonical endpoint for a Workload from its WorkloadPlan
+func (e *EndpointDeriver) DeriveEndpoint(
+	ctx context.Context,
+	workload *scorev1b1.Workload,
+	plan *scorev1b1.WorkloadPlan,
+) (string, error) {
+	if plan == nil {
+		return "", nil
+	}
+
+	// 1. Check template endpoint configuration
+	if plan.Spec.Template != nil && plan.Spec.Values != nil {
+		if templateEndpoint, err := e.extractTemplateEndpoint(plan); err == nil && templateEndpoint != "" {
+			return e.normalizeEndpoint(templateEndpoint, workload, plan)
+		}
+	}
+
+	// 2. Apply service port name prioritization
+	if serviceEndpoint := e.deriveFromServicePorts(workload); serviceEndpoint != "" {
+		return e.normalizeEndpoint(serviceEndpoint, workload, plan)
+	}
+
+	// 3. No endpoint derivable
+	return "", nil
+}
+
+// extractTemplateEndpoint extracts endpoint from template values
+func (e *EndpointDeriver) extractTemplateEndpoint(plan *scorev1b1.WorkloadPlan) (string, error) {
+	// For MVP, we assume template values contain an "endpoint" field
+	// In a real implementation, this would parse the template values
+	// and extract endpoint configuration based on template kind
+
+	// TODO: Implement actual template parsing based on template.Kind
+	// For now, return empty to fall back to service-based derivation
+	return "", nil
+}
+
+// deriveFromServicePorts derives endpoint from service port configuration
+func (e *EndpointDeriver) deriveFromServicePorts(workload *scorev1b1.Workload) string {
+	service := workload.Spec.Service
+	if service == nil || len(service.Ports) == 0 {
+		return ""
+	}
+
+	// Get prioritized port
+	port := e.selectBestPort(service.Ports)
+	if port == nil {
+		return ""
+	}
+
+	// Generate base endpoint
+	scheme := e.getSchemeForPort(port)
+	hostname := e.generateHostname(workload)
+
+	// Build endpoint
+	endpoint := fmt.Sprintf("%s://%s", scheme, hostname)
+
+	// Add port if non-standard
+	if !e.isStandardPort(scheme, port.Port) {
+		endpoint = fmt.Sprintf("%s:%d", endpoint, port.Port)
+	}
+
+	return endpoint
+}
+
+// selectBestPort selects the best port using prioritization rules
+func (e *EndpointDeriver) selectBestPort(ports []scorev1b1.ServicePort) *scorev1b1.ServicePort {
+	if len(ports) == 0 {
+		return nil
+	}
+
+	if len(ports) == 1 {
+		return &ports[0]
+	}
+
+	// Prioritize by port characteristics (since Score spec doesn't have named ports)
+	prioritized := e.prioritizePortsByCharacteristics(ports)
+	if len(prioritized) > 0 {
+		return &prioritized[0]
+	}
+
+	// Fallback to first port
+	return &ports[0]
+}
+
+// prioritizePortsByCharacteristics prioritizes ports by port number characteristics
+// Priority: HTTPS ports (443, 8443) > HTTP ports (80, 8080) > others
+func (e *EndpointDeriver) prioritizePortsByCharacteristics(ports []scorev1b1.ServicePort) []scorev1b1.ServicePort {
+	// Create a slice of ports with their priority scores
+	type portWithPriority struct {
+		port     scorev1b1.ServicePort
+		priority int
+		isHTTPS  bool
+	}
+
+	prioritizedPorts := make([]portWithPriority, 0, len(ports))
+
+	for _, port := range ports {
+		p := portWithPriority{
+			port:    port,
+			isHTTPS: e.isHTTPSPort(port.Port),
+		}
+
+		// Assign priority based on port characteristics
+		switch {
+		case e.isHTTPSPort(port.Port):
+			p.priority = 1 // HTTPS ports have highest priority
+		case e.isHTTPPort(port.Port):
+			p.priority = 2 // HTTP ports have second priority
+		default:
+			p.priority = 10 // Other ports have lower priority
+		}
+
+		prioritizedPorts = append(prioritizedPorts, p)
+	}
+
+	// Sort by priority (lower number = higher priority), then prefer HTTPS
+	sort.Slice(prioritizedPorts, func(i, j int) bool {
+		if prioritizedPorts[i].priority != prioritizedPorts[j].priority {
+			return prioritizedPorts[i].priority < prioritizedPorts[j].priority
+		}
+		// If same priority, prefer HTTPS
+		return prioritizedPorts[i].isHTTPS && !prioritizedPorts[j].isHTTPS
+	})
+
+	// Extract ports from sorted slice
+	result := make([]scorev1b1.ServicePort, len(prioritizedPorts))
+	for i, p := range prioritizedPorts {
+		result[i] = p.port
+	}
+
+	return result
+}
+
+// isHTTPSPort determines if a port should use HTTPS scheme based on port number
+func (e *EndpointDeriver) isHTTPSPort(port int32) bool {
+	return port == 443 || port == 8443
+}
+
+// isHTTPPort determines if a port is a common HTTP port
+func (e *EndpointDeriver) isHTTPPort(port int32) bool {
+	return port == 80 || port == 8080
+}
+
+// getSchemeForPort returns the appropriate scheme for a port
+func (e *EndpointDeriver) getSchemeForPort(port *scorev1b1.ServicePort) string {
+	if e.isHTTPSPort(port.Port) {
+		return schemeHTTPS
+	}
+	return schemeHTTP
+}
+
+// generateHostname generates hostname for the workload
+func (e *EndpointDeriver) generateHostname(workload *scorev1b1.Workload) string {
+	// For MVP, generate a simple hostname
+	// In production, this would be based on ingress configuration
+	return fmt.Sprintf("%s.%s.svc.cluster.local", workload.Name, workload.Namespace)
+}
+
+// isStandardPort checks if the port is standard for the scheme
+func (e *EndpointDeriver) isStandardPort(scheme string, port int32) bool {
+	return (scheme == schemeHTTP && port == 80) ||
+		(scheme == schemeHTTPS && port == 443)
+}
+
+// normalizeEndpoint applies normalization rules to the derived endpoint
+func (e *EndpointDeriver) normalizeEndpoint(endpoint string, workload *scorev1b1.Workload, _ *scorev1b1.WorkloadPlan) (string, error) {
+	if endpoint == "" {
+		return "", nil
+	}
+
+	// Apply template rendering if needed
+	rendered := e.renderEndpointTemplate(endpoint, workload)
+
+	// Apply existing normalization from derive.go without HTTPS preference
+	// The scheme should be determined by port selection logic, not forced
+	normalized := normalizeEndpoint(rendered, nil)
+
+	// Validate the final endpoint
+	if err := ValidateEndpoint(normalized); err != nil {
+		return "", fmt.Errorf("invalid derived endpoint: %w", err)
+	}
+
+	return normalized, nil
+}
+
+// renderEndpointTemplate renders template variables in endpoint
+func (e *EndpointDeriver) renderEndpointTemplate(endpoint string, workload *scorev1b1.Workload) string {
+	result := endpoint
+	result = strings.ReplaceAll(result, "{{.Name}}", workload.Name)
+	result = strings.ReplaceAll(result, "{{.Namespace}}", workload.Namespace)
+
+	// Add more template variables as needed
+	return result
+}

--- a/internal/endpoint/derivation_test.go
+++ b/internal/endpoint/derivation_test.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+)
+
+func TestEndpointDeriver_DeriveEndpoint(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := scorev1b1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("Failed to add scheme: %v", err)
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	deriver := NewEndpointDeriver(client)
+
+	tests := []struct {
+		name     string
+		workload *scorev1b1.Workload
+		plan     *scorev1b1.WorkloadPlan
+		want     string
+		wantErr  bool
+	}{
+		{
+			name: "no plan returns empty endpoint",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+			},
+			plan:    nil,
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "single http port",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Service: &scorev1b1.ServiceSpec{
+						Ports: []scorev1b1.ServicePort{
+							{
+								Port: 8080,
+							},
+						},
+					},
+				},
+			},
+			plan: &scorev1b1.WorkloadPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+			},
+			want:    "http://test-workload.test-ns.svc.cluster.local:8080",
+			wantErr: false,
+		},
+		{
+			name: "https port prioritized over http",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Service: &scorev1b1.ServiceSpec{
+						Ports: []scorev1b1.ServicePort{
+							{
+								Port: 8080,
+							},
+							{
+								Port: 8443,
+							},
+						},
+					},
+				},
+			},
+			plan: &scorev1b1.WorkloadPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+			},
+			want:    "https://test-workload.test-ns.svc.cluster.local:8443",
+			wantErr: false,
+		},
+		{
+			name: "https port prioritized over non-standard port",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Service: &scorev1b1.ServiceSpec{
+						Ports: []scorev1b1.ServicePort{
+							{
+								Port: 8443,
+							},
+							{
+								Port: 3000,
+							},
+							{
+								Port: 8080,
+							},
+						},
+					},
+				},
+			},
+			plan: &scorev1b1.WorkloadPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+			},
+			want:    "https://test-workload.test-ns.svc.cluster.local:8443",
+			wantErr: false,
+		},
+		{
+			name: "standard port 80 omitted",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Service: &scorev1b1.ServiceSpec{
+						Ports: []scorev1b1.ServicePort{
+							{
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+			plan: &scorev1b1.WorkloadPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+			},
+			want:    "http://test-workload.test-ns.svc.cluster.local",
+			wantErr: false,
+		},
+		{
+			name: "standard port 443 omitted",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+				Spec: scorev1b1.WorkloadSpec{
+					Service: &scorev1b1.ServiceSpec{
+						Ports: []scorev1b1.ServicePort{
+							{
+								Port: 443,
+							},
+						},
+					},
+				},
+			},
+			plan: &scorev1b1.WorkloadPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workload",
+					Namespace: "test-ns",
+				},
+			},
+			want:    "https://test-workload.test-ns.svc.cluster.local",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := deriver.DeriveEndpoint(context.TODO(), tt.workload, tt.plan)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EndpointDeriver.DeriveEndpoint() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("EndpointDeriver.DeriveEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEndpointDeriver_prioritizePortsByCharacteristics(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	deriver := NewEndpointDeriver(client)
+
+	tests := []struct {
+		name  string
+		ports []scorev1b1.ServicePort
+		want  []int32 // Expected port numbers in priority order
+	}{
+		{
+			name: "https port has highest priority",
+			ports: []scorev1b1.ServicePort{
+				{Port: 3000},
+				{Port: 8443},
+				{Port: 8080},
+			},
+			want: []int32{8443, 8080, 3000},
+		},
+		{
+			name: "http port over unknown port",
+			ports: []scorev1b1.ServicePort{
+				{Port: 3000},
+				{Port: 8080},
+			},
+			want: []int32{8080, 3000},
+		},
+		{
+			name: "standard https port prioritized",
+			ports: []scorev1b1.ServicePort{
+				{Port: 8080},
+				{Port: 443},
+			},
+			want: []int32{443, 8080},
+		},
+		{
+			name: "standard http port prioritized",
+			ports: []scorev1b1.ServicePort{
+				{Port: 3000},
+				{Port: 80},
+			},
+			want: []int32{80, 3000},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriver.prioritizePortsByCharacteristics(tt.ports)
+			if len(got) != len(tt.want) {
+				t.Errorf("prioritizePortsByCharacteristics() returned %d ports, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i, expectedPort := range tt.want {
+				if got[i].Port != expectedPort {
+					t.Errorf("prioritizePortsByCharacteristics()[%d].Port = %v, want %v", i, got[i].Port, expectedPort)
+				}
+			}
+		})
+	}
+}
+
+func TestEndpointDeriver_isHTTPSPort(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	deriver := NewEndpointDeriver(client)
+
+	tests := []struct {
+		name    string
+		portNum int32
+		want    bool
+	}{
+		{"port 443", 443, true},
+		{"port 8443", 8443, true},
+		{"port 80", 80, false},
+		{"port 8080", 8080, false},
+		{"random port", 3000, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriver.isHTTPSPort(tt.portNum); got != tt.want {
+				t.Errorf("isHTTPSPort(%v) = %v, want %v", tt.portNum, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEndpointDeriver_isHTTPPort(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	deriver := NewEndpointDeriver(client)
+
+	tests := []struct {
+		name    string
+		portNum int32
+		want    bool
+	}{
+		{"port 80", 80, true},
+		{"port 8080", 8080, true},
+		{"port 443", 443, false},
+		{"port 8443", 8443, false},
+		{"random port", 3000, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriver.isHTTPPort(tt.portNum); got != tt.want {
+				t.Errorf("isHTTPPort(%v) = %v, want %v", tt.portNum, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEndpointDeriver_generateHostname(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	deriver := NewEndpointDeriver(client)
+
+	tests := []struct {
+		name     string
+		workload *scorev1b1.Workload
+		want     string
+	}{
+		{
+			name: "basic hostname generation",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-app",
+					Namespace: "production",
+				},
+			},
+			want: "my-app.production.svc.cluster.local",
+		},
+		{
+			name: "default namespace",
+			workload: &scorev1b1.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+				},
+			},
+			want: "test-service.default.svc.cluster.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriver.generateHostname(tt.workload); got != tt.want {
+				t.Errorf("generateHostname() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEndpointDeriver_isStandardPort(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	deriver := NewEndpointDeriver(client)
+
+	tests := []struct {
+		name   string
+		scheme string
+		port   int32
+		want   bool
+	}{
+		{"HTTP port 80", "http", 80, true},
+		{"HTTPS port 443", "https", 443, true},
+		{"HTTP port 8080", "http", 8080, false},
+		{"HTTPS port 8443", "https", 8443, false},
+		{"HTTP port 443", "http", 443, false},
+		{"HTTPS port 80", "https", 80, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriver.isStandardPort(tt.scheme, tt.port); got != tt.want {
+				t.Errorf("isStandardPort(%v, %v) = %v, want %v", tt.scheme, tt.port, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add WorkloadPlan endpoint derivation capability to enable automatic
service URL generation from workload service specifications. Port-based
prioritization determines appropriate URL schemes with HTTPS ports taking
precedence over HTTP ports.

Update sample workloads with required backend constraint labels to ensure
reproducible testing without manual patches.