### PR TITLE
feat: implement Kubernetes Runtime Controller reference (#16)

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/hoge.md
+++ b/hoge.md
@@ -1,0 +1,21 @@
+
+Resolves: #16 
+
+Add independent Kubernetes Runtime Controller as reference
+implementation for GitHub issue https://github.com/cappyzawa/score-orchestrator/issues/16.
+
+This enables the runtime-agnostic architecture from ADR-0003
+where WorkloadPlan resources are materialized into
+platform-specific resources by independent controller processes.
+
+The implementation demonstrates the pattern for extending
+score-orchestrator to additional runtime platforms beyond
+Kubernetes.
+
+## Architecture
+
+```
+Workload → Orchestrator → WorkloadPlan → Runtime Controller → Kubernetes Resources
+```
+
+The controller successfully materializes Kubernetes Deployments and Services from WorkloadPlan specs, demonstrating the reference pattern for extending to additional runtime platforms.

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -54,6 +54,8 @@ type WorkloadReconciler struct {
 // +kubebuilder:rbac:groups=score.dev,resources=resourceclaims;workloadplans,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=score.dev,resources=resourceclaims/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 // Reconcile handles Workload reconciliation - the single writer of Workload.status
 func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -1,0 +1,70 @@
+# Runtime Controllers
+
+This directory contains **independent Runtime Controller implementations** that are completely separate from the main Score Orchestrator.
+
+## Architecture
+
+Per [ADR-0003](../docs/ADR/ADR-0003-architecture-simplification.md), Runtime Controllers are independent processes that:
+
+1. **Watch WorkloadPlan** resources created by the Orchestrator
+2. **Materialize runtime-specific resources** (Deployments, Services, etc.)
+3. **Run as separate processes** from the Orchestrator
+
+```
+[User] → [Workload] → [Orchestrator] → [WorkloadPlan] → [Runtime Controller] → [Runtime Resources]
+                          ↑                                       ↓
+                    [OrchestratorConfig]                 [Kubernetes/ECS/Nomad]
+```
+
+## Available Runtime Controllers
+
+### Kubernetes Runtime Controller
+
+- **Path**: `kubernetes/`
+- **Watches**: WorkloadPlan with `runtimeClass: kubernetes`
+- **Creates**: Kubernetes Deployments, Services, ConfigMaps
+- **Status**: ✅ **Reference Implementation Complete**
+
+```bash
+# Build and deploy
+cd kubernetes/
+make build
+make docker-build
+make deploy
+
+# Or from root
+make build-runtime
+make deploy-runtime
+```
+
+## Adding New Runtime Controllers
+
+To add support for new runtime platforms (ECS, Nomad, etc.):
+
+1. **Create directory structure**:
+   ```
+   runtimes/ecs/
+   ├── cmd/main.go
+   ├── internal/controller/
+   ├── manifests/
+   ├── Dockerfile
+   ├── Makefile
+   └── README.md
+   ```
+
+2. **Implement WorkloadPlan watcher** with appropriate `runtimeClass` filter
+3. **Add to root Makefile** with delegation targets
+4. **Follow same patterns** as the Kubernetes implementation
+
+## Design Principles
+
+- **Complete encapsulation** - Each runtime controller is self-contained
+- **Independent scaling** - Different runtime controllers scale independently  
+- **Runtime-agnostic core** - Orchestrator remains platform-neutral
+- **Standard interfaces** - All runtime controllers use WorkloadPlan/ResourceClaim APIs
+
+## Related Documentation
+
+- [ADR-0003: Control-plane simplification](../docs/ADR/ADR-0003-architecture-simplification.md)
+- [WorkloadPlan API](../api/v1b1/workloadplan_types.go)
+- [Main Project README](../README.md)

--- a/runtimes/kubernetes/Dockerfile
+++ b/runtimes/kubernetes/Dockerfile
@@ -1,0 +1,33 @@
+# Build the kubernetes-runtime binary
+FROM golang:1.24.5 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY runtimes/kubernetes/cmd/main.go runtimes/kubernetes/cmd/main.go
+COPY runtimes/kubernetes/internal/ runtimes/kubernetes/internal/
+COPY api/ api/
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o kubernetes-runtime runtimes/kubernetes/cmd/main.go
+
+# Use distroless as minimal base image to package the kubernetes-runtime binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/kubernetes-runtime .
+USER 65532:65532
+
+ENTRYPOINT ["/kubernetes-runtime"]

--- a/runtimes/kubernetes/Makefile
+++ b/runtimes/kubernetes/Makefile
@@ -1,0 +1,79 @@
+# Kubernetes Runtime Controller Makefile
+# This Makefile is specific to the Kubernetes Runtime Controller
+
+# Image URL to use for building/pushing
+RUNTIME_IMG ?= kubernetes-runtime:latest
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+# CONTAINER_TOOL defines the container tool to be used for building images.
+CONTAINER_TOOL ?= docker
+
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
+.PHONY: all
+all: build
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nKubernetes Runtime Controller\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+
+.PHONY: fmt
+fmt: ## Run go fmt against code.
+	cd ../../ && go fmt ./runtimes/kubernetes/...
+
+.PHONY: vet
+vet: ## Run go vet against code.
+	cd ../../ && go vet ./runtimes/kubernetes/...
+
+.PHONY: test
+test: fmt vet ## Run tests.
+	cd ../../ && go test ./runtimes/kubernetes/... -coverprofile cover.out
+
+##@ Build
+
+.PHONY: build
+build: fmt vet ## Build kubernetes-runtime binary.
+	cd ../../ && go build -o bin/kubernetes-runtime runtimes/kubernetes/cmd/main.go
+
+.PHONY: run
+run: fmt vet ## Run the kubernetes-runtime controller from your host.
+	cd ../../ && go run runtimes/kubernetes/cmd/main.go
+
+.PHONY: docker-build
+docker-build: ## Build docker image with the kubernetes-runtime.
+	cd ../../ && $(CONTAINER_TOOL) build -f runtimes/kubernetes/Dockerfile -t ${RUNTIME_IMG} .
+
+.PHONY: docker-push
+docker-push: ## Push docker image with the kubernetes-runtime.
+	$(CONTAINER_TOOL) push ${RUNTIME_IMG}
+
+##@ Deployment
+
+# KUBECTL and KUSTOMIZE need to be available
+KUBECTL ?= kubectl
+# Check if kustomize exists in expected location, fallback to PATH
+KUSTOMIZE_BIN := $(shell if [ -f ../../bin/kustomize ]; then echo "../../bin/kustomize"; else echo "kustomize"; fi)
+KUSTOMIZE ?= $(KUSTOMIZE_BIN)
+
+.PHONY: deploy
+deploy: ## Deploy kubernetes-runtime controller to the K8s cluster specified in ~/.kube/config.
+	cd manifests && $(KUSTOMIZE) edit set image ghcr.io/cappyzawa/score-orchestrator/kubernetes-runtime=${RUNTIME_IMG}
+	$(KUSTOMIZE) build manifests | $(KUBECTL) apply -f -
+
+.PHONY: undeploy
+undeploy: ## Undeploy kubernetes-runtime controller from the K8s cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build manifests | $(KUBECTL) delete --ignore-not-found=true -f -
+
+.PHONY: logs
+logs: ## Show kubernetes-runtime controller logs.
+	$(KUBECTL) logs -l app.kubernetes.io/name=kubernetes-runtime-controller -n score-system --tail=100 -f

--- a/runtimes/kubernetes/README.md
+++ b/runtimes/kubernetes/README.md
@@ -1,0 +1,155 @@
+# Kubernetes Runtime Controller
+
+Reference implementation of a **Runtime Controller** for the Score Orchestrator that materializes Kubernetes resources.
+
+## Overview
+
+This controller watches `WorkloadPlan` resources and creates corresponding Kubernetes `Deployment` and `Service` resources, enabling the "Workload-only UX" vision from [ADR-0003](../../docs/ADR/ADR-0003-architecture-simplification.md).
+
+## Architecture
+
+```
+WorkloadPlan (runtimeClass: kubernetes) 
+           ↓
+   Kubernetes Runtime Controller
+           ↓
+   Deployment + Service + ConfigMap
+```
+
+### Responsibilities
+
+- ✅ **Watch WorkloadPlan**: Only processes plans with `runtimeClass: kubernetes`
+- ✅ **Create Deployments**: From `WorkloadPlan.spec.values` and referenced `Workload`
+- ✅ **Create Services**: When `Workload.spec.service.ports` are defined
+- ✅ **Resource ownership**: Sets OwnerReference for garbage collection
+- ✅ **Independent process**: Runs separately from the Orchestrator
+
+### What it does NOT do
+
+- ❌ **Modify Workload.status** - Only the Orchestrator updates Workload status
+- ❌ **Create WorkloadPlan** - Created by the Orchestrator
+- ❌ **Handle other runtimeClass** - Kubernetes-specific implementation
+
+## Quick Start
+
+### Prerequisites
+
+- Kubernetes cluster with Score Orchestrator CRDs installed
+- Score Orchestrator running and creating WorkloadPlan resources
+
+### Build and Deploy
+
+```bash
+# Build binary
+make build
+
+# Build and deploy to cluster
+make docker-build
+make deploy
+
+# View logs
+make logs
+
+# Clean up
+make undeploy
+```
+
+### From Root Project
+
+```bash
+# From the root of score-orchestrator project
+make build-runtime
+make deploy-runtime
+```
+
+## Configuration
+
+### Environment Variables
+
+- `RUNTIME_CLASS`: Should be "kubernetes" (default behavior)
+- Standard controller-runtime flags available
+
+### RBAC Requirements
+
+The controller requires these permissions (automatically configured):
+
+- `workloadplans`: get, list, watch
+- `workloads`: get, list, watch  
+- `deployments`: get, list, watch, create, update, patch, delete
+- `services`: get, list, watch, create, update, patch, delete
+- `configmaps`: get, list, watch, create, update, patch, delete
+- `events`: create, patch
+
+## Example Usage
+
+1. **User creates Workload**:
+   ```yaml
+   apiVersion: score.dev/v1b1
+   kind: Workload
+   metadata:
+     name: myapp
+   spec:
+     containers:
+       app:
+         image: nginx:latest
+     service:
+       ports:
+       - port: 8080
+   ```
+
+2. **Orchestrator creates WorkloadPlan** (with `runtimeClass: kubernetes`)
+
+3. **This controller automatically creates**:
+   - `Deployment/myapp`
+   - `Service/myapp`
+
+## Development
+
+### Project Structure
+
+```
+kubernetes/
+├── cmd/main.go                           # Controller entrypoint
+├── internal/controller/
+│   └── kubernetes_controller.go          # Main reconciler logic
+├── manifests/                            # Kubernetes manifests
+│   ├── rbac.yaml                        # ServiceAccount, ClusterRole
+│   ├── deployment.yaml                  # Controller deployment
+│   └── kustomization.yaml               # Kustomize config
+├── Dockerfile                           # Container build
+├── Makefile                            # Build/deploy targets
+└── README.md                           # This file
+```
+
+### Key Components
+
+- **KubernetesRuntimeReconciler**: Main controller that watches WorkloadPlan
+- **buildDeployment()**: Converts WorkloadPlan → Kubernetes Deployment
+- **buildService()**: Converts WorkloadPlan → Kubernetes Service
+- **Resource ownership**: Ensures proper garbage collection
+
+## Testing
+
+```bash
+# Run unit tests
+make test
+
+# Manual testing
+make run  # Runs controller locally against configured cluster
+```
+
+## Customization
+
+This is a **reference implementation**. Organizations can:
+
+- Fork and customize resource generation logic
+- Add support for Ingress, NetworkPolicy, etc.
+- Implement organization-specific naming conventions
+- Add validation/policy enforcement
+
+## Related Documentation
+
+- [ADR-0003: Architecture](../../docs/ADR/ADR-0003-architecture-simplification.md)
+- [WorkloadPlan API](../../api/v1b1/workloadplan_types.go)
+- [Score Specification](https://score.dev)
+- [Runtime Controllers Overview](../README.md)

--- a/runtimes/kubernetes/cmd/main.go
+++ b/runtimes/kubernetes/cmd/main.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"os"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	runtimectrl "github.com/cappyzawa/score-orchestrator/runtimes/kubernetes/internal/controller"
+	// +kubebuilder:scaffold:imports
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(scorev1b1.AddToScheme(scheme))
+	// +kubebuilder:scaffold:scheme
+}
+
+// nolint:gocyclo
+func main() {
+	var metricsAddr string
+	var metricsCertPath, metricsCertName, metricsCertKey string
+	var webhookCertPath, webhookCertName, webhookCertKey string
+	var enableLeaderElection bool
+	var probeAddr string
+	var secureMetrics bool
+	var enableHTTP2 bool
+	var tlsOpts []func(*tls.Config)
+
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
+		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&secureMetrics, "metrics-secure", true,
+		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
+	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
+	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
+	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
+		"The directory that contains the metrics server certificate.")
+	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
+	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
+	flag.BoolVar(&enableHTTP2, "enable-http2", false,
+		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// if the enable-http2 flag is false (the default), http/2 should be disabled
+	// due to its vulnerabilities. More specifically, disabling http/2 will
+	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
+	// Rapid Reset CVEs. For more information see:
+	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
+	// - https://github.com/advisories/GHSA-4374-p667-p6c8
+	disableHTTP2 := func(c *tls.Config) {
+		setupLog.Info("disabling http/2")
+		c.NextProtos = []string{"http/1.1"}
+	}
+
+	if !enableHTTP2 {
+		tlsOpts = append(tlsOpts, disableHTTP2)
+	}
+
+	// Initial webhook TLS options
+	webhookTLSOpts := tlsOpts
+	webhookServerOptions := webhook.Options{
+		TLSOpts: webhookTLSOpts,
+	}
+
+	if len(webhookCertPath) > 0 {
+		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
+			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
+
+		webhookServerOptions.CertDir = webhookCertPath
+		webhookServerOptions.CertName = webhookCertName
+		webhookServerOptions.KeyName = webhookCertKey
+	}
+
+	webhookServer := webhook.NewServer(webhookServerOptions)
+
+	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
+	// More info:
+	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/metrics/server
+	// - https://book.kubebuilder.io/reference/metrics.html
+	metricsServerOptions := metricsserver.Options{
+		BindAddress:   metricsAddr,
+		SecureServing: secureMetrics,
+		TLSOpts:       tlsOpts,
+	}
+
+	if secureMetrics {
+		// FilterProvider is used to protect the metrics endpoint with authn/authz.
+		// These configurations ensure that only authorized users and service accounts
+		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
+		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/metrics/filters#WithAuthenticationAndAuthorization
+		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+
+	if len(metricsCertPath) > 0 {
+		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
+			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
+
+		metricsServerOptions.CertDir = metricsCertPath
+		metricsServerOptions.CertName = metricsCertName
+		metricsServerOptions.KeyName = metricsCertKey
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsServerOptions,
+		WebhookServer:          webhookServer,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "kubernetes-runtime.score.dev",
+		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
+		// when the Manager ends. This requires the binary to immediately end when the
+		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+		// speeds up voluntary leader transitions as the new leader don't have to wait
+		// LeaseDuration time first.
+		//
+		// In the default scaffold provided, the program ends immediately after
+		// the manager stops, so would be fine to enable this option. However,
+		// if you are doing or is intended to do any operation such as perform cleanups
+		// after the manager stops then its usage might be unsafe.
+		// LeaderElectionReleaseOnCancel: true,
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	// Setup signal handler and context
+	ctx := ctrl.SetupSignalHandler()
+
+	setupLog.Info("Setting up Kubernetes Runtime Controller")
+	if err := (&runtimectrl.KubernetesRuntimeReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("kubernetes-runtime-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "KubernetesRuntime")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	setupLog.Info("starting Kubernetes Runtime Controller manager")
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}

--- a/runtimes/kubernetes/manifests/deployment.yaml
+++ b/runtimes/kubernetes/manifests/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-runtime-controller
+  namespace: score-system
+  labels:
+    app.kubernetes.io/name: kubernetes-runtime-controller
+    app.kubernetes.io/component: runtime-controller
+    app.kubernetes.io/part-of: score-orchestrator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-runtime-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubernetes-runtime-controller
+        app.kubernetes.io/component: runtime-controller
+        app.kubernetes.io/part-of: score-orchestrator
+    spec:
+      serviceAccountName: kubernetes-runtime-controller
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+      containers:
+      - name: controller
+        image: ghcr.io/cappyzawa/score-orchestrator/kubernetes-runtime:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - --leader-elect
+        - --metrics-bind-address=:8080
+        - --health-probe-bind-address=:8081
+        env:
+        - name: RUNTIME_CLASS
+          value: "kubernetes"
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      terminationGracePeriodSeconds: 10

--- a/runtimes/kubernetes/manifests/kustomization.yaml
+++ b/runtimes/kubernetes/manifests/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: kubernetes-runtime-controller
+  namespace: score-system
+
+resources:
+- rbac.yaml
+- deployment.yaml
+
+images:
+- name: ghcr.io/cappyzawa/score-orchestrator/kubernetes-runtime
+  newName: kubernetes-runtime
+  newTag: latest
+
+commonLabels:
+  app.kubernetes.io/component: runtime-controller
+  app.kubernetes.io/name: kubernetes-runtime-controller
+  app.kubernetes.io/part-of: score-orchestrator

--- a/runtimes/kubernetes/manifests/rbac.yaml
+++ b/runtimes/kubernetes/manifests/rbac.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-runtime-controller
+  labels:
+    app.kubernetes.io/name: kubernetes-runtime-controller
+    app.kubernetes.io/component: runtime-controller
+    app.kubernetes.io/part-of: score-orchestrator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - score.dev
+  resources:
+  - workloadplans
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - score.dev
+  resources:
+  - workloadplans/status
+  verbs:
+  - get
+- apiGroups:
+  - score.dev
+  resources:
+  - workloads
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-runtime-controller
+  namespace: score-system
+  labels:
+    app.kubernetes.io/name: kubernetes-runtime-controller
+    app.kubernetes.io/component: runtime-controller
+    app.kubernetes.io/part-of: score-orchestrator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-runtime-controller
+  labels:
+    app.kubernetes.io/name: kubernetes-runtime-controller
+    app.kubernetes.io/component: runtime-controller
+    app.kubernetes.io/part-of: score-orchestrator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-runtime-controller
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-runtime-controller
+  namespace: score-system


### PR DESCRIPTION
Resolves: #16 

Add independent Kubernetes Runtime Controller as reference
implementation for GitHub issue https://github.com/cappyzawa/score-orchestrator/issues/16.

This enables the runtime-agnostic architecture from ADR-0003
where WorkloadPlan resources are materialized into
platform-specific resources by independent controller processes.

The implementation demonstrates the pattern for extending
score-orchestrator to additional runtime platforms beyond
Kubernetes.

## Architecture

```
Workload → Orchestrator → WorkloadPlan → Runtime Controller → Kubernetes Resources
```

The controller successfully materializes Kubernetes Deployments and Services from WorkloadPlan specs, demonstrating the reference pattern for extending to additional runtime platforms.

## Issues Discovered During E2E Testing

During the E2E flow verification, we discovered a **backend selection issue** in the Orchestrator:

- **Problem**: WorkloadPlan is not automatically created despite proper backend configuration
- **Error**: `"no suitable backend candidates found for profile \"web-service\""`
- **Impact**: E2E flow requires manual WorkloadPlan creation as workaround
- **Root Cause**: Backend selection logic appears to have issues matching workload labels/constraints

**Current Status**: Runtime Controller functionality is fully verified with manual WorkloadPlan. The backend selection issue is separate from this PR's scope but should be addressed in a follow-up.