### PR TITLE
Refactor: Extract ResourceClaim management logic into dedicated Claim…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
 	"github.com/cappyzawa/score-orchestrator/internal/config"
 	"github.com/cappyzawa/score-orchestrator/internal/controller"
+	"github.com/cappyzawa/score-orchestrator/internal/controller/managers"
 	"github.com/cappyzawa/score-orchestrator/internal/endpoint"
 	// +kubebuilder:scaffold:imports
 )
@@ -204,12 +205,20 @@ func main() {
 	}
 	configLoader := config.NewConfigMapLoader(clientset, loaderOptions)
 
+	// Create ClaimManager
+	claimManager := managers.NewClaimManager(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("claim-manager"),
+	)
+
 	if err := (&controller.WorkloadReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		Recorder:        mgr.GetEventRecorderFor("workload-controller"),
 		ConfigLoader:    configLoader,
 		EndpointDeriver: endpoint.NewEndpointDeriver(mgr.GetClient()),
+		ClaimManager:    claimManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Workload")
 		os.Exit(1)

--- a/internal/controller/managers/claim_manager.go
+++ b/internal/controller/managers/claim_manager.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/conditions"
+	"github.com/cappyzawa/score-orchestrator/internal/meta"
+	"github.com/cappyzawa/score-orchestrator/internal/status"
+)
+
+// ClaimManager handles ResourceClaim operations for Workloads
+type ClaimManager struct {
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder record.EventRecorder
+}
+
+// NewClaimManager creates a new ClaimManager instance
+func NewClaimManager(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *ClaimManager {
+	return &ClaimManager{
+		client:   c,
+		scheme:   scheme,
+		recorder: recorder,
+	}
+}
+
+// EnsureClaims creates or updates ResourceClaim resources for each resource in the Workload spec
+func (cm *ClaimManager) EnsureClaims(ctx context.Context, workload *scorev1b1.Workload) error {
+	for key, resource := range workload.Spec.Resources {
+		if err := cm.upsertResourceClaim(ctx, workload, key, resource); err != nil {
+			return fmt.Errorf("failed to upsert ResourceClaim for key %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// upsertResourceClaim creates or updates a single ResourceClaim
+func (cm *ClaimManager) upsertResourceClaim(ctx context.Context, workload *scorev1b1.Workload, key string, resource scorev1b1.ResourceSpec) error {
+	claimName := fmt.Sprintf("%s-%s", workload.Name, key)
+	claim := &scorev1b1.ResourceClaim{}
+
+	log := ctrl.LoggerFrom(ctx).WithValues("claimName", claimName, "workload", workload.Name, "key", key)
+	log.Info("Upserting ResourceClaim")
+
+	// Try to get existing claim
+	err := cm.client.Get(ctx, types.NamespacedName{
+		Name:      claimName,
+		Namespace: workload.Namespace,
+	}, claim)
+
+	if err != nil && !errors.IsNotFound(err) {
+		log.Error(err, "Failed to get ResourceClaim")
+		return fmt.Errorf("failed to get ResourceClaim %s: %w", claimName, err)
+	}
+
+	// Prepare the desired spec
+	desiredSpec := scorev1b1.ResourceClaimSpec{
+		WorkloadRef: scorev1b1.NamespacedName{
+			Name:      workload.Name,
+			Namespace: workload.Namespace,
+		},
+		Key:  key,
+		Type: resource.Type,
+	}
+
+	// Set optional fields if present
+	if resource.Class != nil {
+		desiredSpec.Class = resource.Class
+	}
+	if resource.Params != nil {
+		desiredSpec.Params = resource.Params
+	}
+
+	if errors.IsNotFound(err) {
+		log.Info("Creating new ResourceClaim")
+		// Create new claim
+		claim = &scorev1b1.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      claimName,
+				Namespace: workload.Namespace,
+				Labels: map[string]string{
+					"score.dev/workload": workload.Name,
+					"score.dev/key":      key,
+				},
+			},
+			Spec: desiredSpec,
+		}
+
+		// Set owner reference
+		if err := controllerutil.SetControllerReference(workload, claim, cm.scheme); err != nil {
+			log.Error(err, "Failed to set owner reference")
+			return fmt.Errorf("failed to set owner reference: %w", err)
+		}
+
+		if err := cm.client.Create(ctx, claim); err != nil {
+			log.Error(err, "Failed to create ResourceClaim")
+			return fmt.Errorf("failed to create ResourceClaim: %w", err)
+		}
+		log.Info("Successfully created ResourceClaim")
+	} else {
+		log.Info("ResourceClaim already exists, checking for updates")
+		// Update existing claim if spec differs
+		if !cm.resourceClaimSpecEqual(claim.Spec, desiredSpec) {
+			log.Info("Updating ResourceClaim spec")
+			claim.Spec = desiredSpec
+			if err := cm.client.Update(ctx, claim); err != nil {
+				log.Error(err, "Failed to update ResourceClaim")
+				return fmt.Errorf("failed to update ResourceClaim: %w", err)
+			}
+			log.Info("Successfully updated ResourceClaim")
+		} else {
+			log.Info("ResourceClaim spec is up to date")
+		}
+	}
+
+	return nil
+}
+
+// resourceClaimSpecEqual compares two ResourceClaimSpec structs for equality
+func (cm *ClaimManager) resourceClaimSpecEqual(a, b scorev1b1.ResourceClaimSpec) bool {
+	if a.WorkloadRef != b.WorkloadRef || a.Key != b.Key || a.Type != b.Type {
+		return false
+	}
+
+	// Compare optional string pointers
+	if (a.Class == nil) != (b.Class == nil) {
+		return false
+	}
+	if a.Class != nil && *a.Class != *b.Class {
+		return false
+	}
+
+	if (a.ID == nil) != (b.ID == nil) {
+		return false
+	}
+	if a.ID != nil && *a.ID != *b.ID {
+		return false
+	}
+
+	// For Params (JSON), we do a simple nil check
+	// More sophisticated comparison could be added if needed
+	if (a.Params == nil) != (b.Params == nil) {
+		return false
+	}
+
+	return true
+}
+
+// GetClaims retrieves all ResourceClaims for a given Workload
+func (cm *ClaimManager) GetClaims(ctx context.Context, workload *scorev1b1.Workload) ([]scorev1b1.ResourceClaim, error) {
+	claimList := &scorev1b1.ResourceClaimList{}
+	key := fmt.Sprintf("%s/%s", workload.Namespace, workload.Name)
+
+	// Try using indexer first, fallback to label selector for tests
+	err := cm.client.List(ctx, claimList, client.MatchingFields{meta.IndexResourceClaimByWorkload: key})
+	if err != nil && (err.Error() == "field label not supported: resourceclaim.workloadRef" ||
+		strings.Contains(err.Error(), "no index with name resourceclaim.workloadRef has been registered")) {
+		// Fallback: use label selector when indexer is not available (e.g., in tests)
+		return cm.getResourceClaimsWithoutIndex(ctx, workload)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return claimList.Items, nil
+}
+
+// getResourceClaimsWithoutIndex retrieves ResourceClaims using owner reference or labels
+func (cm *ClaimManager) getResourceClaimsWithoutIndex(ctx context.Context, workload *scorev1b1.Workload) ([]scorev1b1.ResourceClaim, error) {
+	claimList := &scorev1b1.ResourceClaimList{}
+
+	// Use label selector to find claims for this workload
+	err := cm.client.List(ctx, claimList,
+		client.InNamespace(workload.Namespace),
+		client.MatchingLabels{"score.dev/workload": workload.Name})
+	if err != nil {
+		return nil, err
+	}
+
+	return claimList.Items, nil
+}
+
+// AggregateStatus processes all ResourceClaims and returns aggregated status
+func (cm *ClaimManager) AggregateStatus(claims []scorev1b1.ResourceClaim) status.ClaimAggregation {
+	if len(claims) == 0 {
+		return status.ClaimAggregation{
+			Ready:   false,
+			Reason:  conditions.ReasonClaimPending,
+			Message: conditions.MessageNoClaimsFound,
+			Claims:  []scorev1b1.ClaimSummary{},
+		}
+	}
+
+	summaries := make([]scorev1b1.ClaimSummary, 0, len(claims))
+	var boundCount, failedCount int
+
+	for _, claim := range claims {
+		summary := scorev1b1.ClaimSummary{
+			Key:              claim.Spec.Key,
+			Phase:            claim.Status.Phase,
+			Reason:           claim.Status.Reason,
+			Message:          claim.Status.Message,
+			OutputsAvailable: claim.Status.OutputsAvailable,
+		}
+
+		// Handle empty phase as Pending
+		if summary.Phase == "" {
+			summary.Phase = scorev1b1.ResourceClaimPhasePending
+		}
+
+		summaries = append(summaries, summary)
+
+		// Count phases for overall status
+		switch claim.Status.Phase {
+		case scorev1b1.ResourceClaimPhaseBound:
+			if claim.Status.OutputsAvailable {
+				boundCount++
+			}
+		case scorev1b1.ResourceClaimPhaseFailed:
+			failedCount++
+		}
+	}
+
+	// Determine overall claim readiness
+	totalClaims := len(claims)
+	var ready bool
+	var reason, message string
+
+	if failedCount > 0 {
+		ready = false
+		reason = conditions.ReasonClaimFailed
+		message = conditions.MessageClaimsFailed
+	} else if boundCount == totalClaims {
+		ready = true
+		reason = conditions.ReasonSucceeded
+		message = conditions.MessageAllClaimsReady
+	} else {
+		ready = false
+		reason = conditions.ReasonClaimPending
+		message = conditions.MessageClaimsProvisioning
+	}
+
+	return status.ClaimAggregation{
+		Ready:   ready,
+		Reason:  reason,
+		Message: message,
+		Claims:  summaries,
+	}
+}

--- a/internal/controller/managers/claim_manager_test.go
+++ b/internal/controller/managers/claim_manager_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managers
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/conditions"
+)
+
+func TestClaimManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ClaimManager Suite")
+}
+
+var _ = Describe("ClaimManager", func() {
+	var (
+		ctx          context.Context
+		claimManager *ClaimManager
+		fakeClient   client.Client
+		scheme       *runtime.Scheme
+		recorder     *record.FakeRecorder
+		workload     *scorev1b1.Workload
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(scorev1b1.AddToScheme(scheme)).To(Succeed())
+
+		recorder = record.NewFakeRecorder(10)
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+		claimManager = NewClaimManager(fakeClient, scheme, recorder)
+
+		// Create a test workload
+		workload = &scorev1b1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-workload",
+				Namespace: "default",
+			},
+			Spec: scorev1b1.WorkloadSpec{
+				Resources: map[string]scorev1b1.ResourceSpec{
+					"db": {
+						Type:  "postgresql",
+						Class: stringPtr("standard"),
+					},
+					"cache": {
+						Type: "redis",
+					},
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, workload)).To(Succeed())
+	})
+
+	Describe("EnsureClaims", func() {
+		It("should create ResourceClaims for all resources in the workload", func() {
+			err := claimManager.EnsureClaims(ctx, workload)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify db claim was created
+			dbClaim := &scorev1b1.ResourceClaim{}
+			err = fakeClient.Get(ctx, types.NamespacedName{
+				Name:      "test-workload-db",
+				Namespace: "default",
+			}, dbClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dbClaim.Spec.Type).To(Equal("postgresql"))
+			Expect(dbClaim.Spec.Class).ToNot(BeNil())
+			Expect(*dbClaim.Spec.Class).To(Equal("standard"))
+			Expect(dbClaim.Spec.Key).To(Equal("db"))
+
+			// Verify cache claim was created
+			cacheClaim := &scorev1b1.ResourceClaim{}
+			err = fakeClient.Get(ctx, types.NamespacedName{
+				Name:      "test-workload-cache",
+				Namespace: "default",
+			}, cacheClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cacheClaim.Spec.Type).To(Equal("redis"))
+			Expect(cacheClaim.Spec.Class).To(BeNil())
+			Expect(cacheClaim.Spec.Key).To(Equal("cache"))
+		})
+
+		It("should update existing claims when spec changes", func() {
+			// Create initial claim
+			err := claimManager.EnsureClaims(ctx, workload)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Update workload spec
+			dbResource := workload.Spec.Resources["db"]
+			dbResource.Class = stringPtr("premium")
+			workload.Spec.Resources["db"] = dbResource
+			Expect(fakeClient.Update(ctx, workload)).To(Succeed())
+
+			// Ensure claims again
+			err = claimManager.EnsureClaims(ctx, workload)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify claim was updated
+			dbClaim := &scorev1b1.ResourceClaim{}
+			err = fakeClient.Get(ctx, types.NamespacedName{
+				Name:      "test-workload-db",
+				Namespace: "default",
+			}, dbClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*dbClaim.Spec.Class).To(Equal("premium"))
+		})
+	})
+
+	Describe("GetClaims", func() {
+		It("should retrieve claims using label selector", func() {
+			// Create claims first
+			err := claimManager.EnsureClaims(ctx, workload)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Get claims
+			claims, err := claimManager.GetClaims(ctx, workload)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims).To(HaveLen(2))
+
+			// Verify claims contain expected keys
+			keys := make([]string, len(claims))
+			for i, claim := range claims {
+				keys[i] = claim.Spec.Key
+			}
+			Expect(keys).To(ContainElements("db", "cache"))
+		})
+
+		It("should return empty slice when no claims exist", func() {
+			claims, err := claimManager.GetClaims(ctx, workload)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims).To(BeEmpty())
+		})
+	})
+
+	Describe("AggregateStatus", func() {
+		It("should return not ready when no claims", func() {
+			agg := claimManager.AggregateStatus([]scorev1b1.ResourceClaim{})
+			Expect(agg.Ready).To(BeFalse())
+			Expect(agg.Reason).To(Equal(conditions.ReasonClaimPending))
+			Expect(agg.Message).To(Equal(conditions.MessageNoClaimsFound))
+			Expect(agg.Claims).To(BeEmpty())
+		})
+
+		It("should return ready when all claims are bound with outputs", func() {
+			claims := []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "db"},
+					Status: scorev1b1.ResourceClaimStatus{
+						Phase:            scorev1b1.ResourceClaimPhaseBound,
+						OutputsAvailable: true,
+						Reason:           conditions.ReasonSucceeded,
+						Message:          "Database ready",
+					},
+				},
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "cache"},
+					Status: scorev1b1.ResourceClaimStatus{
+						Phase:            scorev1b1.ResourceClaimPhaseBound,
+						OutputsAvailable: true,
+						Reason:           conditions.ReasonSucceeded,
+						Message:          "Cache ready",
+					},
+				},
+			}
+
+			agg := claimManager.AggregateStatus(claims)
+			Expect(agg.Ready).To(BeTrue())
+			Expect(agg.Reason).To(Equal(conditions.ReasonSucceeded))
+			Expect(agg.Message).To(Equal(conditions.MessageAllClaimsReady))
+			Expect(agg.Claims).To(HaveLen(2))
+		})
+
+		It("should return not ready when some claims are pending", func() {
+			claims := []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "db"},
+					Status: scorev1b1.ResourceClaimStatus{
+						Phase:            scorev1b1.ResourceClaimPhaseBound,
+						OutputsAvailable: true,
+					},
+				},
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "cache"},
+					Status: scorev1b1.ResourceClaimStatus{
+						Phase: scorev1b1.ResourceClaimPhasePending,
+					},
+				},
+			}
+
+			agg := claimManager.AggregateStatus(claims)
+			Expect(agg.Ready).To(BeFalse())
+			Expect(agg.Reason).To(Equal(conditions.ReasonClaimPending))
+			Expect(agg.Message).To(Equal(conditions.MessageClaimsProvisioning))
+		})
+
+		It("should return not ready when any claim has failed", func() {
+			claims := []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "db"},
+					Status: scorev1b1.ResourceClaimStatus{
+						Phase:            scorev1b1.ResourceClaimPhaseBound,
+						OutputsAvailable: true,
+					},
+				},
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "cache"},
+					Status: scorev1b1.ResourceClaimStatus{
+						Phase: scorev1b1.ResourceClaimPhaseFailed,
+					},
+				},
+			}
+
+			agg := claimManager.AggregateStatus(claims)
+			Expect(agg.Ready).To(BeFalse())
+			Expect(agg.Reason).To(Equal(conditions.ReasonClaimFailed))
+			Expect(agg.Message).To(Equal(conditions.MessageClaimsFailed))
+		})
+
+		It("should handle empty phase as pending", func() {
+			claims := []scorev1b1.ResourceClaim{
+				{
+					Spec: scorev1b1.ResourceClaimSpec{Key: "db"},
+					Status: scorev1b1.ResourceClaimStatus{
+						Phase: "", // Empty phase should be treated as pending
+					},
+				},
+			}
+
+			agg := claimManager.AggregateStatus(claims)
+			Expect(agg.Claims[0].Phase).To(Equal(scorev1b1.ResourceClaimPhasePending))
+		})
+	})
+})
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -30,6 +30,7 @@ import (
 	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
 	"github.com/cappyzawa/score-orchestrator/internal/conditions"
 	"github.com/cappyzawa/score-orchestrator/internal/config"
+	"github.com/cappyzawa/score-orchestrator/internal/controller/managers"
 	"github.com/cappyzawa/score-orchestrator/internal/endpoint"
 	"github.com/cappyzawa/score-orchestrator/internal/reconcile"
 )
@@ -41,6 +42,7 @@ type WorkloadReconciler struct {
 	Recorder        record.EventRecorder
 	ConfigLoader    config.ConfigLoader
 	EndpointDeriver *endpoint.EndpointDeriver
+	ClaimManager    *managers.ClaimManager
 }
 
 // +kubebuilder:rbac:groups=score.dev,resources=workloads,verbs=get;list;watch;update;patch

--- a/internal/controller/workload_lifecycle.go
+++ b/internal/controller/workload_lifecycle.go
@@ -47,7 +47,7 @@ func (r *WorkloadReconciler) handleDeletion(ctx context.Context, workload *score
 	}
 
 	// Wait for ResourceClaims to be cleaned up by their owners (Provisioners)
-	claims, err := GetResourceClaimsForWorkload(ctx, r.Client, workload)
+	claims, err := r.ClaimManager.GetClaims(ctx, workload)
 	if err != nil {
 		log.Error(err, "Failed to get ResourceClaims during deletion")
 		return ctrl.Result{}, err


### PR DESCRIPTION
Resolves: #34 

Extract scattered ResourceClaim management logic into a centralized ClaimManager to improve maintainability and separation of concerns.

This consolidates claim creation, retrieval, and status aggregation logic that was previously spread across multiple files, making the codebase easier to maintain and test.

All existing functionality preserved with no behavioral changes.