### PR TITLE
Refactor: Extract WorkloadPlan management logic into dedicated PlanManager

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -212,6 +212,15 @@ func main() {
 		mgr.GetEventRecorderFor("claim-manager"),
 	)
 
+	// Create PlanManager
+	planManager := managers.NewPlanManager(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("plan-manager"),
+		configLoader,
+		endpoint.NewEndpointDeriver(mgr.GetClient()),
+	)
+
 	if err := (&controller.WorkloadReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
@@ -219,6 +228,7 @@ func main() {
 		ConfigLoader:    configLoader,
 		EndpointDeriver: endpoint.NewEndpointDeriver(mgr.GetClient()),
 		ClaimManager:    claimManager,
+		PlanManager:     planManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Workload")
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -61,6 +62,7 @@ require (
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect
@@ -98,7 +100,6 @@ require (
 	k8s.io/component-base v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/kubebuilder/v4 v4.8.0 // indirect

--- a/internal/controller/managers/plan_manager.go
+++ b/internal/controller/managers/plan_manager.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/conditions"
+	"github.com/cappyzawa/score-orchestrator/internal/config"
+	"github.com/cappyzawa/score-orchestrator/internal/endpoint"
+	"github.com/cappyzawa/score-orchestrator/internal/meta"
+	"github.com/cappyzawa/score-orchestrator/internal/reconcile"
+	"github.com/cappyzawa/score-orchestrator/internal/selection"
+	"github.com/cappyzawa/score-orchestrator/internal/status"
+)
+
+// Plan management events
+const (
+	// EventReasonPlanCreated indicates successful workload plan creation
+	EventReasonPlanCreated = "PlanCreated"
+	// EventReasonPlanError indicates an error in workload plan creation
+	EventReasonPlanError = "PlanError"
+	// EventReasonProjectionError indicates an error in workload projection
+	EventReasonProjectionError = "ProjectionError"
+)
+
+// Event types
+const (
+	// EventTypeNormal indicates a normal event
+	EventTypeNormal = "Normal"
+	// EventTypeWarning indicates a warning event
+	EventTypeWarning = "Warning"
+)
+
+// PlanManager handles WorkloadPlan operations for Workloads
+type PlanManager struct {
+	client          client.Client
+	scheme          *runtime.Scheme
+	recorder        record.EventRecorder
+	configLoader    config.ConfigLoader
+	endpointDeriver *endpoint.EndpointDeriver
+}
+
+// NewPlanManager creates a new PlanManager instance
+func NewPlanManager(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, configLoader config.ConfigLoader, endpointDeriver *endpoint.EndpointDeriver) *PlanManager {
+	return &PlanManager{
+		client:          c,
+		scheme:          scheme,
+		recorder:        recorder,
+		configLoader:    configLoader,
+		endpointDeriver: endpointDeriver,
+	}
+}
+
+// EnsurePlan creates WorkloadPlan if bindings are ready
+func (pm *PlanManager) EnsurePlan(ctx context.Context, workload *scorev1b1.Workload, claims []scorev1b1.ResourceClaim, agg status.ClaimAggregation) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Create WorkloadPlan if claims are ready
+	if agg.Ready {
+		log.V(1).Info("Claims are ready, creating WorkloadPlan")
+		selectedBackend, err := pm.SelectBackend(ctx, workload)
+		if err != nil {
+			log.Error(err, "Failed to select backend")
+			conditions.SetCondition(&workload.Status.Conditions,
+				conditions.ConditionRuntimeReady,
+				metav1.ConditionFalse,
+				conditions.ReasonRuntimeSelecting,
+				fmt.Sprintf("Backend selection failed: %v", err))
+			return err
+		}
+
+		if err := reconcile.UpsertWorkloadPlan(ctx, pm.client, workload, claims, selectedBackend); err != nil {
+			log.Error(err, "Failed to upsert WorkloadPlan")
+
+			// Check if this is a projection error (missing outputs)
+			if strings.Contains(err.Error(), "missing required outputs for projection") {
+				conditions.SetCondition(&workload.Status.Conditions,
+					conditions.ConditionRuntimeReady,
+					metav1.ConditionFalse,
+					conditions.ReasonProjectionError,
+					fmt.Sprintf("Cannot create plan: %v", err))
+				pm.recorder.Eventf(workload, EventTypeWarning, EventReasonProjectionError, "Missing required resource outputs: %v", err)
+				return err
+			}
+
+			pm.recorder.Eventf(workload, EventTypeWarning, EventReasonPlanError, "Failed to create workload plan: %v", err)
+			return err
+		}
+		pm.recorder.Eventf(workload, EventTypeNormal, EventReasonPlanCreated, "WorkloadPlan created successfully")
+	} else {
+		log.V(1).Info("Claims are not ready yet", "ready", agg.Ready, "reason", agg.Reason, "message", agg.Message)
+	}
+
+	return nil
+}
+
+// GetPlan retrieves the WorkloadPlan for a given Workload
+func (pm *PlanManager) GetPlan(ctx context.Context, workload *scorev1b1.Workload) (*scorev1b1.WorkloadPlan, error) {
+	planList := &scorev1b1.WorkloadPlanList{}
+	key := fmt.Sprintf("%s/%s", workload.Namespace, workload.Name)
+
+	// Try using indexer first, fallback to label selector for tests
+	err := pm.client.List(ctx, planList, client.MatchingFields{meta.IndexWorkloadPlanByWorkload: key})
+	if err != nil && strings.Contains(err.Error(), "no index with name") {
+		// Fallback: use label selector when indexer is not available (e.g., in tests)
+		err = pm.client.List(ctx, planList,
+			client.InNamespace(workload.Namespace),
+			client.MatchingLabels{"score.dev/workload": workload.Name})
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list WorkloadPlans: %w", err)
+	}
+
+	if len(planList.Items) == 0 {
+		return nil, errors.NewNotFound(scorev1b1.GroupVersion.WithResource("workloadplans").GroupResource(), workload.Name)
+	}
+
+	if len(planList.Items) > 1 {
+		return nil, fmt.Errorf("multiple WorkloadPlans found for Workload %s/%s", workload.Namespace, workload.Name)
+	}
+
+	return &planList.Items[0], nil
+}
+
+// SelectBackend selects the backend for the workload using deterministic profile selection pipeline
+func (pm *PlanManager) SelectBackend(ctx context.Context, workload *scorev1b1.Workload) (*selection.SelectedBackend, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Load Orchestrator Configuration
+	orchestratorConfig, err := pm.configLoader.LoadConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load orchestrator config: %w", err)
+	}
+
+	// Create ProfileSelector
+	selector := selection.NewProfileSelector(orchestratorConfig, pm.client)
+
+	// Select backend using deterministic pipeline
+	selectedBackend, err := selector.SelectBackend(ctx, workload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select backend: %w", err)
+	}
+
+	log.V(1).Info("Selected backend for workload",
+		"backend", selectedBackend.BackendID,
+		"runtime", selectedBackend.RuntimeClass,
+		"template", fmt.Sprintf("%s:%s", selectedBackend.Template.Kind, selectedBackend.Template.Ref))
+
+	return selectedBackend, nil
+}

--- a/internal/controller/managers/plan_manager_test.go
+++ b/internal/controller/managers/plan_manager_test.go
@@ -1,0 +1,362 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/conditions"
+	"github.com/cappyzawa/score-orchestrator/internal/config"
+	"github.com/cappyzawa/score-orchestrator/internal/endpoint"
+	"github.com/cappyzawa/score-orchestrator/internal/status"
+)
+
+// Mock implementations
+type mockConfigLoader struct {
+	mock.Mock
+}
+
+func (m *mockConfigLoader) LoadConfig(ctx context.Context) (*scorev1b1.OrchestratorConfig, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*scorev1b1.OrchestratorConfig), args.Error(1)
+}
+
+func (m *mockConfigLoader) Watch(ctx context.Context) (<-chan config.ConfigEvent, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(<-chan config.ConfigEvent), args.Error(1)
+}
+
+func (m *mockConfigLoader) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+type mockEventRecorder struct {
+	record.EventRecorder
+	events []string
+}
+
+func (m *mockEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	m.events = append(m.events, reason)
+}
+
+func TestPlanManager_EnsurePlan(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, scorev1b1.AddToScheme(scheme))
+
+	workload := &scorev1b1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workload",
+			Namespace: "test-ns",
+		},
+		Spec: scorev1b1.WorkloadSpec{
+			Containers: map[string]scorev1b1.ContainerSpec{
+				"main": {
+					Image: "nginx:latest",
+				},
+			},
+		},
+	}
+
+	claims := []scorev1b1.ResourceClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-claim",
+				Namespace: "test-ns",
+			},
+			Spec: scorev1b1.ResourceClaimSpec{
+				Key:  "database",
+				Type: "postgres",
+			},
+			Status: scorev1b1.ResourceClaimStatus{
+				Phase:            "Bound",
+				OutputsAvailable: true,
+				Outputs: scorev1b1.ResourceClaimOutputs{
+					URI: stringPtr("postgres://localhost:5432/test"),
+				},
+			},
+		},
+	}
+
+	t.Run("EnsurePlan creates plan when claims are ready", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		mockConfigLoader := &mockConfigLoader{}
+		endpointDeriver := endpoint.NewEndpointDeriver(fakeClient)
+		mockRecorder := &mockEventRecorder{}
+
+		pm := NewPlanManager(fakeClient, scheme, mockRecorder, mockConfigLoader, endpointDeriver)
+
+		// Mock config loading
+		testConfig := &scorev1b1.OrchestratorConfig{
+			Spec: scorev1b1.OrchestratorConfigSpec{
+				Profiles: []scorev1b1.ProfileSpec{
+					{
+						Name: "test-profile",
+						Backends: []scorev1b1.BackendSpec{
+							{
+								BackendId:    "test-backend",
+								RuntimeClass: "kubernetes",
+								Priority:     100,
+								Template: scorev1b1.TemplateSpec{
+									Kind:   "manifests",
+									Ref:    "test-template:latest",
+									Values: nil, // Use nil for MVP test
+								},
+							},
+						},
+					},
+				},
+				Defaults: scorev1b1.DefaultsSpec{
+					Profile: "test-profile",
+				},
+			},
+		}
+		mockConfigLoader.On("LoadConfig", mock.Anything).Return(testConfig, nil)
+
+		agg := status.ClaimAggregation{
+			Ready:   true,
+			Message: "All claims are ready",
+		}
+
+		err := pm.EnsurePlan(context.Background(), workload, claims, agg)
+		require.NoError(t, err)
+
+		// Verify WorkloadPlan was created
+		planList := &scorev1b1.WorkloadPlanList{}
+		err = fakeClient.List(context.Background(), planList, client.InNamespace("test-ns"))
+		require.NoError(t, err)
+		assert.Len(t, planList.Items, 1)
+
+		plan := planList.Items[0]
+		assert.Equal(t, "test-workload", plan.Name)
+		assert.Equal(t, "test-ns", plan.Namespace)
+		assert.Equal(t, "kubernetes", plan.Spec.RuntimeClass)
+
+		// Verify event was recorded
+		assert.Contains(t, mockRecorder.events, EventReasonPlanCreated)
+
+		mockConfigLoader.AssertExpectations(t)
+	})
+
+	t.Run("EnsurePlan skips when claims are not ready", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		mockConfigLoader := &mockConfigLoader{}
+		endpointDeriver := endpoint.NewEndpointDeriver(fakeClient)
+		mockRecorder := &mockEventRecorder{}
+
+		pm := NewPlanManager(fakeClient, scheme, mockRecorder, mockConfigLoader, endpointDeriver)
+
+		agg := status.ClaimAggregation{
+			Ready:   false,
+			Message: "Claims are not ready",
+		}
+
+		err := pm.EnsurePlan(context.Background(), workload, claims, agg)
+		require.NoError(t, err)
+
+		// Verify no WorkloadPlan was created
+		planList := &scorev1b1.WorkloadPlanList{}
+		err = fakeClient.List(context.Background(), planList, client.InNamespace("test-ns"))
+		require.NoError(t, err)
+		assert.Len(t, planList.Items, 0)
+
+		// Verify no events were recorded
+		assert.Empty(t, mockRecorder.events)
+
+		// Config loader should not have been called
+		mockConfigLoader.AssertNotCalled(t, "LoadConfig")
+	})
+
+	t.Run("EnsurePlan handles backend selection error", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		mockConfigLoader := &mockConfigLoader{}
+		endpointDeriver := endpoint.NewEndpointDeriver(fakeClient)
+		mockRecorder := &mockEventRecorder{}
+
+		pm := NewPlanManager(fakeClient, scheme, mockRecorder, mockConfigLoader, endpointDeriver)
+
+		// Mock config loading failure
+		mockConfigLoader.On("LoadConfig", mock.Anything).Return((*scorev1b1.OrchestratorConfig)(nil), assert.AnError)
+
+		agg := status.ClaimAggregation{
+			Ready:   true,
+			Message: "All claims are ready",
+		}
+
+		err := pm.EnsurePlan(context.Background(), workload, claims, agg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load orchestrator config")
+
+		// Verify condition was set on workload
+		runtimeCondition := conditions.GetCondition(workload.Status.Conditions, conditions.ConditionRuntimeReady)
+		require.NotNil(t, runtimeCondition)
+		assert.Equal(t, metav1.ConditionFalse, runtimeCondition.Status)
+		assert.Equal(t, conditions.ReasonRuntimeSelecting, runtimeCondition.Reason)
+
+		mockConfigLoader.AssertExpectations(t)
+	})
+}
+
+func TestPlanManager_GetPlan(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, scorev1b1.AddToScheme(scheme))
+
+	workload := &scorev1b1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workload",
+			Namespace: "test-ns",
+		},
+	}
+
+	existingPlan := &scorev1b1.WorkloadPlan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workload",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				"score.dev/workload": "test-workload",
+			},
+		},
+		Spec: scorev1b1.WorkloadPlanSpec{
+			WorkloadRef: scorev1b1.WorkloadPlanWorkloadRef{
+				Name:      "test-workload",
+				Namespace: "test-ns",
+			},
+			RuntimeClass: "kubernetes",
+		},
+	}
+
+	t.Run("GetPlan returns existing plan", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingPlan).Build()
+		mockConfigLoader := &mockConfigLoader{}
+		endpointDeriver := endpoint.NewEndpointDeriver(fakeClient)
+		mockRecorder := &mockEventRecorder{}
+
+		pm := NewPlanManager(fakeClient, scheme, mockRecorder, mockConfigLoader, endpointDeriver)
+
+		plan, err := pm.GetPlan(context.Background(), workload)
+		require.NoError(t, err)
+		require.NotNil(t, plan)
+		assert.Equal(t, "test-workload", plan.Name)
+		assert.Equal(t, "kubernetes", plan.Spec.RuntimeClass)
+	})
+
+	t.Run("GetPlan returns NotFound when plan doesn't exist", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		mockConfigLoader := &mockConfigLoader{}
+		endpointDeriver := endpoint.NewEndpointDeriver(fakeClient)
+		mockRecorder := &mockEventRecorder{}
+
+		pm := NewPlanManager(fakeClient, scheme, mockRecorder, mockConfigLoader, endpointDeriver)
+
+		plan, err := pm.GetPlan(context.Background(), workload)
+		require.Error(t, err)
+		assert.True(t, errors.IsNotFound(err))
+		assert.Nil(t, plan)
+	})
+}
+
+func TestPlanManager_SelectBackend(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, scorev1b1.AddToScheme(scheme))
+
+	workload := &scorev1b1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workload",
+			Namespace: "test-ns",
+		},
+		Spec: scorev1b1.WorkloadSpec{
+			Containers: map[string]scorev1b1.ContainerSpec{
+				"main": {
+					Image: "nginx:latest",
+				},
+			},
+		},
+	}
+
+	t.Run("SelectBackend returns selected backend", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		mockConfigLoader := &mockConfigLoader{}
+		endpointDeriver := endpoint.NewEndpointDeriver(fakeClient)
+		mockRecorder := &mockEventRecorder{}
+
+		pm := NewPlanManager(fakeClient, scheme, mockRecorder, mockConfigLoader, endpointDeriver)
+
+		testConfig := &scorev1b1.OrchestratorConfig{
+			Spec: scorev1b1.OrchestratorConfigSpec{
+				Profiles: []scorev1b1.ProfileSpec{
+					{
+						Name: "test-profile",
+						Backends: []scorev1b1.BackendSpec{
+							{
+								BackendId:    "test-backend",
+								RuntimeClass: "kubernetes",
+								Priority:     100,
+								Template: scorev1b1.TemplateSpec{
+									Kind:   "manifests",
+									Ref:    "test-template:latest",
+									Values: nil, // Use nil for MVP test
+								},
+							},
+						},
+					},
+				},
+				Defaults: scorev1b1.DefaultsSpec{
+					Profile: "test-profile",
+				},
+			},
+		}
+		mockConfigLoader.On("LoadConfig", mock.Anything).Return(testConfig, nil)
+
+		selectedBackend, err := pm.SelectBackend(context.Background(), workload)
+		require.NoError(t, err)
+		require.NotNil(t, selectedBackend)
+		assert.Equal(t, "test-backend", selectedBackend.BackendID)
+		assert.Equal(t, "kubernetes", selectedBackend.RuntimeClass)
+
+		mockConfigLoader.AssertExpectations(t)
+	})
+
+	t.Run("SelectBackend handles config loading error", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		mockConfigLoader := &mockConfigLoader{}
+		endpointDeriver := endpoint.NewEndpointDeriver(fakeClient)
+		mockRecorder := &mockEventRecorder{}
+
+		pm := NewPlanManager(fakeClient, scheme, mockRecorder, mockConfigLoader, endpointDeriver)
+
+		mockConfigLoader.On("LoadConfig", mock.Anything).Return((*scorev1b1.OrchestratorConfig)(nil), assert.AnError)
+
+		selectedBackend, err := pm.SelectBackend(context.Background(), workload)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load orchestrator config")
+		assert.Nil(t, selectedBackend)
+
+		mockConfigLoader.AssertExpectations(t)
+	})
+}

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -43,6 +43,7 @@ type WorkloadReconciler struct {
 	ConfigLoader    config.ConfigLoader
 	EndpointDeriver *endpoint.EndpointDeriver
 	ClaimManager    *managers.ClaimManager
+	PlanManager     *managers.PlanManager
 }
 
 // +kubebuilder:rbac:groups=score.dev,resources=workloads,verbs=get;list;watch;update;patch

--- a/internal/controller/workload_controller_test.go
+++ b/internal/controller/workload_controller_test.go
@@ -163,6 +163,13 @@ spec:
 				mgr.GetScheme(),
 				mgr.GetEventRecorderFor("claim-manager-test-"+testNS.Name),
 			)
+			planManager := managers.NewPlanManager(
+				mgr.GetClient(),
+				mgr.GetScheme(),
+				mgr.GetEventRecorderFor("plan-manager-test-"+testNS.Name),
+				configLoader,
+				endpoint.NewEndpointDeriver(mgr.GetClient()),
+			)
 			reconciler := &WorkloadReconciler{
 				Client:          mgr.GetClient(),
 				Scheme:          mgr.GetScheme(),
@@ -170,6 +177,7 @@ spec:
 				ConfigLoader:    configLoader,
 				EndpointDeriver: endpoint.NewEndpointDeriver(mgr.GetClient()),
 				ClaimManager:    claimManager,
+				PlanManager:     planManager,
 			}
 			// Setup controller directly with unique name to avoid conflicts between tests
 			err = ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
Resolves: #35 

Centralizes WorkloadPlan operations into a dedicated PlanManager following the established manager pattern to improve separation of concerns and maintainability.

The PlanManager handles backend selection, plan creation, and retrieval, simplifying the WorkloadReconciler and providing better testability. This maintains identical behavior while improving code organization according to Domain-Driven Design principles.