### PR TITLE
Refactor: Transform reconciliation into phase-based pipeline

### DIFF
--- a/internal/controller/phases/claim.go
+++ b/internal/controller/phases/claim.go
@@ -1,0 +1,61 @@
+package phases
+
+import (
+	"context"
+
+	"github.com/cappyzawa/score-orchestrator/internal/status"
+)
+
+// Event constants for claim phase
+const (
+	EventTypeWarning      = "Warning"
+	EventReasonClaimError = "ClaimError"
+)
+
+// ClaimPhase handles ResourceClaim creation, update, and status aggregation
+type ClaimPhase struct{}
+
+// Name returns the name of the claim phase
+func (p *ClaimPhase) Name() string {
+	return "Claim"
+}
+
+// Execute performs ResourceClaim operations
+func (p *ClaimPhase) Execute(ctx context.Context, phaseCtx *PhaseContext) PhaseResult {
+	log := phaseCtx.Logger.WithValues("phase", p.Name())
+	log.V(1).Info("Starting claim phase")
+
+	// Create/update ResourceClaims using ClaimManager
+	if err := phaseCtx.ClaimManager.EnsureClaims(ctx, phaseCtx.Workload); err != nil {
+		log.Error(err, "Failed to ensure ResourceClaims")
+		phaseCtx.Recorder.Eventf(phaseCtx.Workload, EventTypeWarning, EventReasonClaimError, "Failed to create resource claims: %v", err)
+		return PhaseResult{Error: err}
+	}
+
+	log.V(1).Info("ResourceClaims ensured successfully")
+
+	// Get and aggregate claim statuses using ClaimManager
+	claims, err := phaseCtx.ClaimManager.GetClaims(ctx, phaseCtx.Workload)
+	if err != nil {
+		log.Error(err, "Failed to get ResourceClaims")
+		return PhaseResult{Error: err}
+	}
+
+	log.V(1).Info("Retrieved ResourceClaims", "count", len(claims))
+
+	// Update context with claim data
+	phaseCtx.Claims = claims
+	phaseCtx.ClaimAgg = phaseCtx.ClaimManager.AggregateStatus(claims)
+
+	// Update workload status from aggregation
+	status.UpdateWorkloadStatusFromAggregation(phaseCtx.Workload, phaseCtx.ClaimAgg)
+
+	log.V(1).Info("Claim phase completed successfully")
+	return PhaseResult{}
+}
+
+// ShouldSkip determines if claim phase should be skipped
+func (p *ClaimPhase) ShouldSkip(ctx context.Context, phaseCtx *PhaseContext) bool {
+	// Skip claim phase during deletion
+	return !phaseCtx.Workload.DeletionTimestamp.IsZero()
+}

--- a/internal/controller/phases/deletion.go
+++ b/internal/controller/phases/deletion.go
@@ -1,0 +1,64 @@
+package phases
+
+import (
+	"context"
+	"time"
+
+	"github.com/cappyzawa/score-orchestrator/internal/reconcile"
+)
+
+// DefaultRequeueDelay is the default delay for requeuing when waiting for resources during deletion
+const DefaultRequeueDelay = 30 * time.Second
+
+// Event constants for deletion phase
+const (
+	EventTypeNormal    = "Normal"
+	EventReasonDeleted = "Deleted"
+)
+
+// DeletionPhase handles workload deletion and cleanup
+type DeletionPhase struct{}
+
+// Name returns the name of the deletion phase
+func (p *DeletionPhase) Name() string {
+	return "Deletion"
+}
+
+// Execute performs workload deletion and cleanup
+func (p *DeletionPhase) Execute(ctx context.Context, phaseCtx *PhaseContext) PhaseResult {
+	log := phaseCtx.Logger.WithValues("phase", p.Name())
+	log.V(1).Info("Starting deletion phase")
+
+	if !reconcile.HasFinalizer(phaseCtx.Workload) {
+		log.V(1).Info("No finalizer present, deletion complete")
+		return PhaseResult{}
+	}
+
+	// Wait for ResourceClaims to be cleaned up by their owners (Provisioners)
+	claims, err := phaseCtx.ClaimManager.GetClaims(ctx, phaseCtx.Workload)
+	if err != nil {
+		log.Error(err, "Failed to get ResourceClaims during deletion")
+		return PhaseResult{Error: err}
+	}
+
+	if len(claims) > 0 {
+		log.V(1).Info("Waiting for ResourceClaims to be cleaned up", "count", len(claims))
+		return PhaseResult{Requeue: true, RequeueAfter: DefaultRequeueDelay}
+	}
+
+	// Remove finalizer
+	if err := reconcile.RemoveFinalizer(ctx, phaseCtx.Client, phaseCtx.Workload); err != nil {
+		log.Error(err, "Failed to remove finalizer")
+		return PhaseResult{Error: err}
+	}
+
+	phaseCtx.Recorder.Event(phaseCtx.Workload, EventTypeNormal, EventReasonDeleted, "Workload cleanup completed")
+	log.V(1).Info("Deletion phase completed successfully")
+	return PhaseResult{}
+}
+
+// ShouldSkip determines if deletion phase should be skipped
+func (p *DeletionPhase) ShouldSkip(ctx context.Context, phaseCtx *PhaseContext) bool {
+	// Deletion phase is only executed when workload is being deleted
+	return phaseCtx.Workload.DeletionTimestamp.IsZero()
+}

--- a/internal/controller/phases/interface.go
+++ b/internal/controller/phases/interface.go
@@ -1,0 +1,67 @@
+package phases
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/controller/managers"
+	"github.com/cappyzawa/score-orchestrator/internal/status"
+)
+
+// PhaseResult represents the result of a phase execution
+type PhaseResult struct {
+	// Skip indicates whether to skip remaining phases
+	Skip bool
+	// Requeue indicates whether to requeue the reconciliation
+	Requeue bool
+	// RequeueAfter indicates when to requeue the reconciliation
+	RequeueAfter time.Duration
+	// Error is the error that occurred during phase execution
+	Error error
+}
+
+// PhaseContext contains shared context and data between phases
+type PhaseContext struct {
+	// Client is the Kubernetes client
+	Client client.Client
+	// Workload is the Workload being reconciled
+	Workload *scorev1b1.Workload
+	// Logger is the controller logger
+	Logger logr.Logger
+	// Recorder is the event recorder
+	Recorder record.EventRecorder
+	// Managers provide domain-specific operations
+	ClaimManager  *managers.ClaimManager
+	PlanManager   *managers.PlanManager
+	StatusManager *managers.StatusManager
+
+	// Phase-specific data
+	Claims            []scorev1b1.ResourceClaim
+	ClaimAgg          status.ClaimAggregation
+	Plan              *scorev1b1.WorkloadPlan
+	InputsValid       bool
+	ValidationReason  string
+	ValidationMessage string
+}
+
+// Phase represents a single phase in the reconciliation pipeline
+type Phase interface {
+	// Name returns the name of the phase for logging
+	Name() string
+	// Execute runs the phase logic
+	Execute(ctx context.Context, phaseCtx *PhaseContext) PhaseResult
+	// ShouldSkip determines if this phase should be skipped based on context
+	ShouldSkip(ctx context.Context, phaseCtx *PhaseContext) bool
+}
+
+// Pipeline manages the execution of reconciliation phases
+type Pipeline interface {
+	// Execute runs all phases in order
+	Execute(ctx context.Context, phaseCtx *PhaseContext) (ctrl.Result, error)
+}

--- a/internal/controller/phases/plan.go
+++ b/internal/controller/phases/plan.go
@@ -1,0 +1,53 @@
+package phases
+
+import (
+	"context"
+	"strings"
+)
+
+// PlanPhase handles WorkloadPlan creation and updates
+type PlanPhase struct{}
+
+// Name returns the name of the plan phase
+func (p *PlanPhase) Name() string {
+	return "Plan"
+}
+
+// Execute performs WorkloadPlan operations
+func (p *PlanPhase) Execute(ctx context.Context, phaseCtx *PhaseContext) PhaseResult {
+	log := phaseCtx.Logger.WithValues("phase", p.Name())
+	log.V(1).Info("Starting plan phase")
+
+	// Ensure WorkloadPlan using PlanManager
+	if err := phaseCtx.PlanManager.EnsurePlan(ctx, phaseCtx.Workload, phaseCtx.Claims, phaseCtx.ClaimAgg); err != nil {
+		log.Error(err, "Failed to ensure WorkloadPlan")
+
+		// Check if this is a status-only error that should trigger immediate return
+		if strings.Contains(err.Error(), "missing required outputs for projection") {
+			log.V(1).Info("Missing required outputs for projection, skipping to status update")
+			return PhaseResult{Skip: true}
+		}
+
+		return PhaseResult{Error: err}
+	}
+
+	// Get the current plan for context
+	plan, err := phaseCtx.PlanManager.GetPlan(ctx, phaseCtx.Workload)
+	if err != nil {
+		log.V(1).Info("Failed to get WorkloadPlan, continuing with nil plan", "error", err)
+		// This is not a fatal error - nil plan is handled elsewhere
+		plan = nil
+	}
+
+	// Update context with plan data
+	phaseCtx.Plan = plan
+
+	log.V(1).Info("Plan phase completed successfully")
+	return PhaseResult{}
+}
+
+// ShouldSkip determines if plan phase should be skipped
+func (p *PlanPhase) ShouldSkip(ctx context.Context, phaseCtx *PhaseContext) bool {
+	// Skip plan phase during deletion
+	return !phaseCtx.Workload.DeletionTimestamp.IsZero()
+}

--- a/internal/controller/phases/status.go
+++ b/internal/controller/phases/status.go
@@ -1,0 +1,51 @@
+package phases
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ConflictRequeueDelay is the delay for requeuing on resource version conflicts
+const ConflictRequeueDelay = 1 * time.Second
+
+// StatusPhase handles final status computation and updates
+type StatusPhase struct{}
+
+// Name returns the name of the status phase
+func (p *StatusPhase) Name() string {
+	return "Status"
+}
+
+// Execute performs final status computation and update
+func (p *StatusPhase) Execute(ctx context.Context, phaseCtx *PhaseContext) PhaseResult {
+	log := phaseCtx.Logger.WithValues("phase", p.Name())
+	log.V(1).Info("Starting status phase")
+
+	// Compute final status using StatusManager
+	if err := phaseCtx.StatusManager.ComputeFinalStatus(ctx, phaseCtx.Workload, phaseCtx.Plan); err != nil {
+		log.Error(err, "Failed to compute final status")
+		return PhaseResult{Error: err}
+	}
+
+	// Update status
+	if err := phaseCtx.StatusManager.UpdateStatus(ctx, phaseCtx.Workload); err != nil {
+		if apierrors.IsConflict(err) {
+			// Resource version conflict - requeue for retry
+			log.V(1).Info("Resource version conflict, requeuing", "error", err)
+			return PhaseResult{Requeue: true, RequeueAfter: ConflictRequeueDelay}
+		}
+		log.Error(err, "Failed to update Workload status")
+		return PhaseResult{Error: err}
+	}
+
+	log.V(1).Info("Status phase completed successfully")
+	return PhaseResult{}
+}
+
+// ShouldSkip determines if status phase should be skipped
+func (p *StatusPhase) ShouldSkip(ctx context.Context, phaseCtx *PhaseContext) bool {
+	// Status phase is always executed for active workloads
+	return !phaseCtx.Workload.DeletionTimestamp.IsZero()
+}

--- a/internal/controller/phases/validation.go
+++ b/internal/controller/phases/validation.go
@@ -1,0 +1,58 @@
+package phases
+
+import (
+	"context"
+
+	"github.com/cappyzawa/score-orchestrator/internal/conditions"
+)
+
+// ValidationPhase handles input validation and policy checks
+type ValidationPhase struct{}
+
+// Name returns the name of the validation phase
+func (p *ValidationPhase) Name() string {
+	return "Validation"
+}
+
+// Execute performs input validation and policy checks
+func (p *ValidationPhase) Execute(ctx context.Context, phaseCtx *PhaseContext) PhaseResult {
+	log := phaseCtx.Logger.WithValues("phase", p.Name())
+	log.V(1).Info("Starting validation phase")
+
+	// Perform validation logic
+	inputsValid, reason, message := p.validateInputsAndPolicy(ctx, phaseCtx)
+
+	// Update context with validation results
+	phaseCtx.InputsValid = inputsValid
+	phaseCtx.ValidationReason = reason
+	phaseCtx.ValidationMessage = message
+
+	// Update status condition
+	phaseCtx.StatusManager.SetInputsValidCondition(phaseCtx.Workload, inputsValid, reason, message)
+
+	if !inputsValid {
+		log.V(1).Info("Inputs validation failed", "reason", reason, "message", message)
+		// Skip remaining phases and update status
+		return PhaseResult{Skip: true}
+	}
+
+	log.V(1).Info("Inputs validated successfully")
+	return PhaseResult{}
+}
+
+// ShouldSkip determines if validation phase should be skipped
+func (p *ValidationPhase) ShouldSkip(ctx context.Context, phaseCtx *PhaseContext) bool {
+	// Validation is always performed for active workloads
+	return !phaseCtx.Workload.DeletionTimestamp.IsZero()
+}
+
+// validateInputsAndPolicy performs the actual validation logic
+// This is extracted to allow for easier testing and future expansion
+func (p *ValidationPhase) validateInputsAndPolicy(_ context.Context, phaseCtx *PhaseContext) (bool, string, string) {
+	// For MVP: basic validation (CRD-level validation handles most cases)
+	// Resources are optional - workloads can be stateless without dependencies
+
+	// ADR-0003: Policy validation is now handled via Orchestrator Config + Admission
+	// For MVP, basic spec validation is sufficient
+	return true, conditions.ReasonSucceeded, "Workload specification is valid"
+}

--- a/internal/controller/reconciler/pipeline.go
+++ b/internal/controller/reconciler/pipeline.go
@@ -1,0 +1,154 @@
+package reconciler
+
+import (
+	"context"
+
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
+	"github.com/cappyzawa/score-orchestrator/internal/controller/managers"
+	"github.com/cappyzawa/score-orchestrator/internal/controller/phases"
+	"github.com/cappyzawa/score-orchestrator/internal/reconcile"
+)
+
+// WorkloadPipeline implements the phase-based reconciliation pipeline
+type WorkloadPipeline struct {
+	client        client.Client
+	recorder      record.EventRecorder
+	claimManager  *managers.ClaimManager
+	planManager   *managers.PlanManager
+	statusManager *managers.StatusManager
+
+	// Phases for normal reconciliation
+	normalPhases []phases.Phase
+	// Phase for deletion
+	deletionPhase phases.Phase
+}
+
+// NewWorkloadPipeline creates a new WorkloadPipeline
+func NewWorkloadPipeline(
+	k8sClient client.Client,
+	recorder record.EventRecorder,
+	claimManager *managers.ClaimManager,
+	planManager *managers.PlanManager,
+	statusManager *managers.StatusManager,
+) *WorkloadPipeline {
+	return &WorkloadPipeline{
+		client:        k8sClient,
+		recorder:      recorder,
+		claimManager:  claimManager,
+		planManager:   planManager,
+		statusManager: statusManager,
+		normalPhases: []phases.Phase{
+			&phases.ValidationPhase{},
+			&phases.ClaimPhase{},
+			&phases.PlanPhase{},
+			&phases.StatusPhase{},
+		},
+		deletionPhase: &phases.DeletionPhase{},
+	}
+}
+
+// Execute runs the reconciliation pipeline
+func (p *WorkloadPipeline) Execute(ctx context.Context, workload *scorev1b1.Workload) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("pipeline", "workload")
+	log.V(1).Info("Starting pipeline execution", "generation", workload.Generation, "resourceVersion", workload.ResourceVersion)
+
+	// Create phase context
+	phaseCtx := &phases.PhaseContext{
+		Client:        p.client,
+		Workload:      workload,
+		Logger:        log,
+		Recorder:      p.recorder,
+		ClaimManager:  p.claimManager,
+		PlanManager:   p.planManager,
+		StatusManager: p.statusManager,
+	}
+
+	// Handle deletion vs normal reconciliation
+	if !workload.DeletionTimestamp.IsZero() {
+		log.V(1).Info("Workload is being deleted, executing deletion pipeline")
+		return p.executeDeletionPipeline(ctx, phaseCtx)
+	}
+
+	// Ensure finalizer for normal reconciliation
+	if err := reconcile.EnsureFinalizer(ctx, p.client, workload); err != nil {
+		log.Error(err, "Failed to ensure finalizer")
+		return ctrl.Result{}, err
+	}
+
+	log.V(1).Info("Executing normal reconciliation pipeline")
+	return p.executeNormalPipeline(ctx, phaseCtx)
+}
+
+// executeNormalPipeline executes the normal reconciliation phases
+func (p *WorkloadPipeline) executeNormalPipeline(ctx context.Context, phaseCtx *phases.PhaseContext) (ctrl.Result, error) {
+	log := phaseCtx.Logger.WithValues("pipeline", "normal")
+
+	for _, phase := range p.normalPhases {
+		// Check if phase should be skipped
+		if phase.ShouldSkip(ctx, phaseCtx) {
+			log.V(1).Info("Skipping phase", "phase", phase.Name())
+			continue
+		}
+
+		log.V(1).Info("Executing phase", "phase", phase.Name())
+		result := phase.Execute(ctx, phaseCtx)
+
+		// Handle phase result
+		if result.Error != nil {
+			log.Error(result.Error, "Phase execution failed", "phase", phase.Name())
+			return ctrl.Result{}, result.Error
+		}
+
+		if result.Requeue {
+			log.V(1).Info("Phase requested requeue", "phase", phase.Name(), "after", result.RequeueAfter)
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: result.RequeueAfter,
+			}, nil
+		}
+
+		if result.Skip {
+			log.V(1).Info("Phase requested to skip remaining phases", "phase", phase.Name())
+			break
+		}
+
+		log.V(1).Info("Phase completed successfully", "phase", phase.Name())
+	}
+
+	log.V(1).Info("Normal pipeline execution completed")
+	return ctrl.Result{}, nil
+}
+
+// executeDeletionPipeline executes the deletion phase
+func (p *WorkloadPipeline) executeDeletionPipeline(ctx context.Context, phaseCtx *phases.PhaseContext) (ctrl.Result, error) {
+	log := phaseCtx.Logger.WithValues("pipeline", "deletion")
+
+	if p.deletionPhase.ShouldSkip(ctx, phaseCtx) {
+		log.V(1).Info("Deletion phase skipped")
+		return ctrl.Result{}, nil
+	}
+
+	log.V(1).Info("Executing deletion phase", "phase", p.deletionPhase.Name())
+	result := p.deletionPhase.Execute(ctx, phaseCtx)
+
+	// Handle phase result
+	if result.Error != nil {
+		log.Error(result.Error, "Deletion phase execution failed", "phase", p.deletionPhase.Name())
+		return ctrl.Result{}, result.Error
+	}
+
+	if result.Requeue {
+		log.V(1).Info("Deletion phase requested requeue", "phase", p.deletionPhase.Name(), "after", result.RequeueAfter)
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: result.RequeueAfter,
+		}, nil
+	}
+
+	log.V(1).Info("Deletion pipeline execution completed")
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/runtime_management.go
+++ b/internal/controller/runtime_management.go
@@ -16,16 +16,6 @@ limitations under the License.
 
 package controller
 
-import (
-	"time"
-)
-
-// Runtime management constants
-const (
-	// ConflictRequeueDelay is the delay for requeuing on resource version conflicts
-	ConflictRequeueDelay = 1 * time.Second
-)
-
 // Runtime management events
 const (
 	// EventReasonProjectionError indicates an error in workload projection


### PR DESCRIPTION
Replace monolithic reconciliation with independent phases to improve testability, maintainability, and extensibility. Each phase handles a specific responsibility and can be tested and modified independently.

The previous approach mixed all reconciliation concerns in a single method, making testing difficult and maintenance complex. This change establishes a foundation for future pipeline enhancements.

Resolves: #37