### PR TITLE
Add additionalPrinterColumns to CRDs for improved kubectl output

### DIFF
--- a/api/v1b1/resourceclaim_types.go
+++ b/api/v1b1/resourceclaim_types.go
@@ -24,6 +24,12 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=rc
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="PHASE",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="TYPE",type="string",JSONPath=".spec.type"
+// +kubebuilder:printcolumn:name="WORKLOAD",type="string",JSONPath=".spec.workloadRef.name"
+// +kubebuilder:printcolumn:name="OUTPUTS",type="boolean",JSONPath=".status.outputsAvailable"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+
 // ResourceClaim represents a single resource dependency resolution contract.
 // Provisioners drive it to Bound and publish standardized outputs for consumption by runtimes.
 type ResourceClaim struct {

--- a/api/v1b1/workload_types.go
+++ b/api/v1b1/workload_types.go
@@ -242,6 +242,10 @@ type WorkloadStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=wl
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="ENDPOINT",type="string",JSONPath=".status.endpoint"
+// +kubebuilder:printcolumn:name="CLAIMS",type="string",JSONPath=".status.claims"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Workload is the Schema for the workloads API
 type Workload struct {

--- a/api/v1b1/workloadplan_types.go
+++ b/api/v1b1/workloadplan_types.go
@@ -23,6 +23,10 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=wplan
+// +kubebuilder:printcolumn:name="RUNTIME",type="string",JSONPath=".spec.runtimeClass"
+// +kubebuilder:printcolumn:name="WORKLOAD",type="string",JSONPath=".spec.workloadRef.name"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+
 // WorkloadPlan is an internal contract from Orchestrator to the Runtime controller.
 // It must not be user-visible via RBAC; status is intentionally omitted.
 type WorkloadPlan struct {

--- a/config/crd/bases/score.dev_resourceclaims.yaml
+++ b/config/crd/bases/score.dev_resourceclaims.yaml
@@ -16,7 +16,23 @@ spec:
     singular: resourceclaim
   scope: Namespaced
   versions:
-  - name: v1b1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: PHASE
+      type: string
+    - jsonPath: .spec.type
+      name: TYPE
+      type: string
+    - jsonPath: .spec.workloadRef.name
+      name: WORKLOAD
+      type: string
+    - jsonPath: .status.outputsAvailable
+      name: OUTPUTS
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1b1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/crd/bases/score.dev_workloadplans.yaml
+++ b/config/crd/bases/score.dev_workloadplans.yaml
@@ -16,7 +16,17 @@ spec:
     singular: workloadplan
   scope: Namespaced
   versions:
-  - name: v1b1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.runtimeClass
+      name: RUNTIME
+      type: string
+    - jsonPath: .spec.workloadRef.name
+      name: WORKLOAD
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1b1
     schema:
       openAPIV3Schema:
         description: |-
@@ -213,3 +223,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/config/crd/bases/score.dev_workloads.yaml
+++ b/config/crd/bases/score.dev_workloads.yaml
@@ -16,7 +16,20 @@ spec:
     singular: workload
   scope: Namespaced
   versions:
-  - name: v1b1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .status.endpoint
+      name: ENDPOINT
+      type: string
+    - jsonPath: .status.claims
+      name: CLAIMS
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1b1
     schema:
       openAPIV3Schema:
         description: Workload is the Schema for the workloads API


### PR DESCRIPTION
Resolves: #64 

Add printer columns to Workload, ResourceClaim, and WorkloadPlan CRDs to display key status information in kubectl get commands.

Workload shows READY status, ENDPOINT URL, CLAIMS summary, and AGE. ResourceClaim displays PHASE, TYPE, associated WORKLOAD, OUTPUTS availability, and AGE.
WorkloadPlan includes RUNTIME class, related WORKLOAD name, and AGE.

This improves debugging and monitoring experience by providing essential status information at a glance without requiring resource description commands.