### PR TITLE
Add CEL validation for Workload CRD fields

### DIFF
--- a/api/v1b1/workload_types.go
+++ b/api/v1b1/workload_types.go
@@ -25,6 +25,7 @@ import (
 type ContainerSpec struct {
 	// Image is the container image reference. Use "." for build-from-source
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:XValidation:rule="self == '.' || !self.startsWith('-') && !self.endsWith('-')",message="image must be '.' for build-from-source or a valid image reference"
 	Image string `json:"image"`
 
 	// Command to run in the container
@@ -58,6 +59,7 @@ type ContainerSpec struct {
 }
 
 // FileSpec defines a file to be mounted in the container
+// +kubebuilder:validation:XValidation:rule="(has(self.source) ? 1 : 0) + (has(self.content) ? 1 : 0) + (has(self.binaryContent) ? 1 : 0) == 1",message="exactly one of source, content, or binaryContent must be specified"
 type FileSpec struct {
 	// Target path where the file should be mounted
 	// +kubebuilder:validation:MinLength=1
@@ -182,6 +184,7 @@ type WorkloadSpec struct {
 	// Containers define the containers in the workload
 	// +kubebuilder:validation:MinProperties=1
 	// +kubebuilder:validation:MaxProperties=10
+	// +kubebuilder:validation:XValidation:rule="size(self) > 0",message="containers must contain at least one container"
 	Containers map[string]ContainerSpec `json:"containers"`
 
 	// Service defines the service configuration

--- a/config/crd/bases/score.dev_workloads.yaml
+++ b/config/crd/bases/score.dev_workloads.yaml
@@ -101,6 +101,11 @@ spec:
                         required:
                         - target
                         type: object
+                        x-kubernetes-validations:
+                        - message: exactly one of source, content, or binaryContent
+                            must be specified
+                          rule: '(has(self.source) ? 1 : 0) + (has(self.content) ?
+                            1 : 0) + (has(self.binaryContent) ? 1 : 0) == 1'
                       maxItems: 20
                       type: array
                     image:
@@ -108,6 +113,10 @@ spec:
                         for build-from-source
                       minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: image must be '.' for build-from-source or a valid
+                          image reference
+                        rule: self == '.' || !self.startsWith('-') && !self.endsWith('-')
                     livenessProbe:
                       description: LivenessProbe defines the liveness probe for the
                         container
@@ -209,6 +218,9 @@ spec:
                 maxProperties: 10
                 minProperties: 1
                 type: object
+                x-kubernetes-validations:
+                - message: containers must contain at least one container
+                  rule: size(self) > 0
               profile:
                 description: |-
                   Profile specifies which orchestrator profile to use for this workload


### PR DESCRIPTION
Add XValidation markers to enforce Score specification invariants at the API level:

- ContainerSpec.image: Must be '.' or valid image reference format
- FileSpec: Exactly one of source, content, or binaryContent required
- WorkloadSpec.containers: Must contain at least one container

These validations provide client-side validation before Kubernetes API server processing, improving user experience and reducing invalid resource creation attempts.

Resolves: #49 