### PR TITLE
Implement DeprovisionPolicy-aware deletion in workload finalizer

### DIFF
--- a/docs/spec/crds.md
+++ b/docs/spec/crds.md
@@ -168,7 +168,10 @@ Provisioners watch this resource, provision/bind concrete services, and publish 
 - `id` (optional): bind to an existing instance
 - `params` (optional): free-form resolver config
 - `deprovisionPolicy` (optional): Enum { **Delete**, **Retain**, **Orphan** }.
-  Defines how provisioned resources are handled when the claim is removed.
+  Defines how provisioned resources are handled when the claim is removed:
+  - `Delete` (default): Remove all provisioned resources and secrets
+  - `Retain`: Keep provisioned resources but remove ownership/binding
+  - `Orphan`: Leave resources as-is without any cleanup
 
 ### Status (written by Provisioners)
 - **`phase`**: `Pending → Claiming → (Bound | Failed)` (may re-enter on reconcile)

--- a/internal/controller/phases/deletion.go
+++ b/internal/controller/phases/deletion.go
@@ -3,6 +3,10 @@ package phases
 import (
 	"context"
 
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
 	"github.com/cappyzawa/score-orchestrator/internal/reconcile"
 )
 
@@ -12,6 +16,13 @@ import (
 const (
 	EventTypeNormal    = "Normal"
 	EventReasonDeleted = "Deleted"
+)
+
+// DeprovisionPolicy constants for deletion handling
+const (
+	DeprovisionPolicyDelete = "Delete"
+	DeprovisionPolicyRetain = "Retain"
+	DeprovisionPolicyOrphan = "Orphan"
 )
 
 // DeletionPhase handles workload deletion and cleanup
@@ -32,15 +43,43 @@ func (p *DeletionPhase) Execute(ctx context.Context, phaseCtx *PhaseContext) Pha
 		return PhaseResult{}
 	}
 
-	// Wait for ResourceClaims to be cleaned up by their owners (Provisioners)
+	// Get all ResourceClaims for this Workload
 	claims, err := phaseCtx.ClaimManager.GetClaims(ctx, phaseCtx.Workload)
 	if err != nil {
 		log.Error(err, "Failed to get ResourceClaims during deletion")
 		return PhaseResult{Error: err}
 	}
 
-	if len(claims) > 0 {
-		log.V(1).Info("Waiting for ResourceClaims to be cleaned up", "count", len(claims))
+	// Process each claim according to its DeprovisionPolicy
+	for _, claim := range claims {
+		claimLog := log.WithValues("claim", claim.Name, "claimNamespace", claim.Namespace)
+
+		// Apply DeprovisionPolicy-specific behavior
+		if err := p.processDeprovisionPolicy(ctx, phaseCtx, &claim, claimLog); err != nil {
+			claimLog.Error(err, "Failed to process DeprovisionPolicy")
+			return PhaseResult{Error: err}
+		}
+	}
+
+	// Wait for ResourceClaims to be cleaned up by their owners (Provisioners)
+	// Only wait for claims that should be deleted according to their policy
+	remainingClaims, err := phaseCtx.ClaimManager.GetClaims(ctx, phaseCtx.Workload)
+	if err != nil {
+		log.Error(err, "Failed to get ResourceClaims during deletion check")
+		return PhaseResult{Error: err}
+	}
+
+	claimsToWaitFor := 0
+	for _, claim := range remainingClaims {
+		// Count claims that need to be deleted according to their policy
+		policy := p.getDeprovisionPolicy(&claim)
+		if policy == DeprovisionPolicyDelete {
+			claimsToWaitFor++
+		}
+	}
+
+	if claimsToWaitFor > 0 {
+		log.V(1).Info("Waiting for ResourceClaims to be cleaned up", "count", claimsToWaitFor)
 		requeueDelay := phaseCtx.ReconcilerConfig.Retry.DefaultRequeueDelay
 		return PhaseResult{Requeue: true, RequeueAfter: requeueDelay}
 	}
@@ -54,6 +93,61 @@ func (p *DeletionPhase) Execute(ctx context.Context, phaseCtx *PhaseContext) Pha
 	phaseCtx.Recorder.Event(phaseCtx.Workload, EventTypeNormal, EventReasonDeleted, "Workload cleanup completed")
 	log.V(1).Info("Deletion phase completed successfully")
 	return PhaseResult{}
+}
+
+// processDeprovisionPolicy handles ResourceClaim lifecycle according to its DeprovisionPolicy
+func (p *DeletionPhase) processDeprovisionPolicy(ctx context.Context, phaseCtx *PhaseContext, claim *scorev1b1.ResourceClaim, log logr.Logger) error {
+	policy := p.getDeprovisionPolicy(claim)
+
+	switch policy {
+	case DeprovisionPolicyDelete:
+		// Default behavior: let owner reference handle deletion
+		log.V(1).Info("Processing claim with Delete policy - letting owner reference handle deletion")
+		return nil
+
+	case DeprovisionPolicyRetain:
+		// Remove owner reference to retain the claim but detach from workload
+		log.V(1).Info("Processing claim with Retain policy - removing owner reference")
+		return p.removeOwnerReference(ctx, phaseCtx, claim)
+
+	case DeprovisionPolicyOrphan:
+		// Leave claim as-is, remove owner reference
+		log.V(1).Info("Processing claim with Orphan policy - removing owner reference")
+		return p.removeOwnerReference(ctx, phaseCtx, claim)
+
+	default:
+		// Default to Delete policy if not specified
+		log.V(1).Info("Processing claim with default Delete policy")
+		return nil
+	}
+}
+
+// getDeprovisionPolicy returns the effective DeprovisionPolicy for a claim
+func (p *DeletionPhase) getDeprovisionPolicy(claim *scorev1b1.ResourceClaim) string {
+	if claim.Spec.DeprovisionPolicy != nil {
+		return string(*claim.Spec.DeprovisionPolicy)
+	}
+	// Default to Delete if not specified
+	return DeprovisionPolicyDelete
+}
+
+// removeOwnerReference removes the Workload owner reference from a ResourceClaim
+func (p *DeletionPhase) removeOwnerReference(ctx context.Context, phaseCtx *PhaseContext, claim *scorev1b1.ResourceClaim) error {
+	// Create a copy to modify
+	claimCopy := claim.DeepCopy()
+
+	// Filter out the Workload owner reference
+	var newOwnerRefs []metav1.OwnerReference
+	for _, ownerRef := range claimCopy.OwnerReferences {
+		if ownerRef.Kind != "Workload" || ownerRef.Name != phaseCtx.Workload.Name {
+			newOwnerRefs = append(newOwnerRefs, ownerRef)
+		}
+	}
+
+	claimCopy.OwnerReferences = newOwnerRefs
+
+	// Update the claim
+	return phaseCtx.Client.Update(ctx, claimCopy)
 }
 
 // ShouldSkip determines if deletion phase should be skipped

--- a/internal/controller/workload_lifecycle.go
+++ b/internal/controller/workload_lifecycle.go
@@ -23,4 +23,12 @@ package controller
 const (
 	// EventReasonDeleted indicates successful workload deletion
 	EventReasonDeleted = "Deleted"
+	// EventReasonFinalizerAdded indicates finalizer was added to workload
+	EventReasonFinalizerAdded = "FinalizerAdded"
+
+	// EventReasonFinalizerRemoved indicates finalizer was removed from workload
+	EventReasonFinalizerRemoved = "FinalizerRemoved"
+
+	// EventReasonClaimCleanupPending indicates waiting for claim cleanup
+	EventReasonClaimCleanupPending = "ClaimCleanupPending"
 )


### PR DESCRIPTION
Resolves: #51 

Add ResourceClaim deletion handling based on DeprovisionPolicy during
Workload cleanup to ensure proper resource lifecycle management.

Key changes:
- Process each ResourceClaim according to its DeprovisionPolicy setting
- Delete policy: Standard deletion via OwnerReference (default behavior)
- Retain/Orphan policies: Remove OwnerReference to preserve ResourceClaim
- Wait only for claims with Delete policy during finalizer cleanup
- Add lifecycle event constants for workload deletion tracking
- Include proper error handling and retry logic for policy processing

This ensures controlled cleanup sequence and prevents data loss while
providing flexibility for different resource lifecycle requirements.