### PR TITLE
Implement resource requests/limits parsing in Kubernetes runtime

### DIFF
--- a/test/e2e/fixtures/workloads/basic-web.yaml
+++ b/test/e2e/fixtures/workloads/basic-web.yaml
@@ -12,6 +12,13 @@ spec:
       image: nginx:latest
       variables:
         PORT: "8080"
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "500m"
+          memory: "512Mi"
   service:
     ports:
     - port: 8080

--- a/test/e2e/golden_path_test.go
+++ b/test/e2e/golden_path_test.go
@@ -158,6 +158,17 @@ spec:
 			return err == nil
 		}, time.Minute, time.Second).Should(BeTrue())
 
+		By("Verifying Deployment has correct resource requirements")
+		cmd = exec.Command("kubectl", "get", "deployment", "service-a", "-n", namespaceName,
+			"-o", "jsonpath={.spec.template.spec.containers[0].resources}")
+		output, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		resourcesOutput := strings.TrimSpace(output)
+		Expect(resourcesOutput).To(ContainSubstring("100m"))  // CPU request
+		Expect(resourcesOutput).To(ContainSubstring("64Mi"))  // Memory request
+		Expect(resourcesOutput).To(ContainSubstring("200m"))  // CPU limit
+		Expect(resourcesOutput).To(ContainSubstring("128Mi")) // Memory limit
+
 		By("Waiting for Deployment to be ready")
 		Eventually(func() bool {
 			cmd := exec.Command("kubectl", "get", "deployment", "service-a", "-n", namespaceName,


### PR DESCRIPTION
Resolves: #74 

Parse Score resource specifications and convert them to Kubernetes ResourceRequirements format using resource.ParseQuantity. Support both CPU and memory resources with proper error handling for invalid formats.

Changes:
- Add resource parsing logic in buildDeployment method
- Handle requests and limits separately with validation
- Return errors for invalid resource format strings
- Update E2E tests to verify resource requirements are applied
- Add resource specifications to test fixtures