### PR TITLE
docs: align spec to orchestrator-side placeholder detection and terminology updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ Score defines a portable way to describe applications. This project provides a s
 - A reference **orchestrator** built around Kubernetes CRDs (group/version: `score.dev/v1b1`)
 - Public API surface: **`Workload`** only
 - Internal contracts for platform use: `ResourceClaim`, `WorkloadPlan`
-- Status is abstract and user-centric (a single `endpoint`, abstract `conditions`, binding summaries)
+- Status is abstract and user-centric (a single `endpoint`, abstract `conditions`, claim summaries)
 - Validation boundary: **CRD OpenAPI + CEL** for spec invariants; org policy via **VAP/OPA/Kyverno**
+
+## What happens when dependencies are not ready?
+When required outputs from `ResourceClaim` resolvers contain unresolved `${...}` placeholders, the Orchestrator detects this before emitting a `WorkloadPlan`. Instead of passing unresolved values to the runtime, it sets `Workload.status` with `RuntimeReady=False` and `Reason=ProjectionError`. Once resolver outputs are complete, the Orchestrator emits the Plan and the Workload converges to Ready.
 
 ## Design tenets (at a glance)
 - **Runtime-agnostic UX** — no runtime-specific nouns in user-visible docs
 - **Single-writer status** — only the orchestrator updates `Workload.status`
-- **Separation of concerns** — plan vs. bindings; users vs. platform
+- **Separation of concerns** — plan vs. claims; users vs. platform
 - **RBAC by default** — users see only `Workload`
 
 ## Documentation

--- a/docs/ADR/ADR-0005-unified-provisioner-controller-design.md
+++ b/docs/ADR/ADR-0005-unified-provisioner-controller-design.md
@@ -110,7 +110,7 @@ Focus on implementing the fundamental Provisioner Controller that can watch and 
 
 #### Phase 1.2: ResourceClaim Status Management
 - [ ] Implement ResourceClaim status updates according to spec
-  - [ ] Support phase transitions: `Pending → Claiming → (Bound | Failed)`
+  - [ ] Support phase transitions: `Pending → Binding → (Bound | Failed)`
   - [ ] Update `reason` and `message` with abstract vocabulary
   - [ ] Implement `outputsAvailable` boolean gate
   - [ ] Track `observedGeneration` and `lastTransitionTime`

--- a/docs/ADR/ADR-0006-terminology-placeholder-pivot.md
+++ b/docs/ADR/ADR-0006-terminology-placeholder-pivot.md
@@ -1,0 +1,20 @@
+# ADR-0006 — Terminology & Placeholder Handling Pivot
+
+## Status
+Accepted • Supersedes parts of ADR-0003 (without modifying ADR-0003 itself).
+
+## Context
+After implementing the initial design, we converged on two changes:
+1) Rename **ResourceBinding** to **ResourceClaim** to better reflect the ownership and lifecycle.
+2) Detect unresolved `${...}` placeholders **inside the Orchestrator before plan emission**. We no longer rely on CEL/admission for deep/opaque JSON scanning.
+
+## Decision
+- Documentation uses **ResourceClaim** across the board.
+- The Orchestrator short-circuits plan emission when placeholders remain and surfaces
+  `RuntimeReady=False` with `Reason=ProjectionError` on `Workload.status`.
+- `WorkloadPlan` remains **internal and minimal** (projection contract only).
+
+## Consequences
+- Clearer user-facing failures; avoids leaking unresolved values to runtimes.
+- Keeps public CRDs simple; validation boundaries stay: OpenAPI+CEL (spec invariants), VAP/OPA/Kyverno (org policy).
+- Existing ADRs remain immutable as historical record.

--- a/docs/spec/control-plane.md
+++ b/docs/spec/control-plane.md
@@ -64,7 +64,18 @@ projection:
   imageFrom: { claimKey: "build-tool", outputKey: "image" }
 ```
 
+## Orchestrator Plan Emission Gate
+
+Before emitting a `WorkloadPlan`, the Orchestrator performs **unresolved placeholder detection**:
+
+1. **Values Composition**: Combine template defaults, normalized Workload spec, and ResourceClaim outputs
+2. **Placeholder Scanning**: Traverse all string fields in composed values to detect `${...}` patterns
+3. **Emission Control**: If unresolved placeholders found, skip Plan creation and set `RuntimeReady=False` with `Reason=ProjectionError`
+4. **Recovery Path**: Automatic reconciliation when ResourceClaim outputs become available
+
+This ensures no unresolved placeholders reach the runtime while providing clear, abstract feedback to users.
+
 ## Error mapping (abstract reasons for `Workload.status`)
 - Claim in progress/failure → `ClaimPending` / `ClaimFailed`
-- Outputs missing/mismatched vs plan → `ProjectionError`
+- Unresolved placeholders prevent plan emission → `ProjectionError`
 - Runtime health/materialization issues → `RuntimeDegraded` (no runtime-specific nouns in messages)

--- a/docs/spec/orchestrator-config.md
+++ b/docs/spec/orchestrator-config.md
@@ -471,6 +471,21 @@ Where:
 
 **Projection failures (normative):** Missing required outputs in `${resources.<key>.outputs.<name>}` MUST set `RuntimeReady=False (ProjectionError)`.
 
+### Placeholder Detection and Error Handling
+
+The Orchestrator performs **pre-emission validation** of composed values to ensure no unresolved placeholders reach the WorkloadPlan:
+
+**Detection Process**:
+1. **Values Composition**: Combine template defaults, normalized Workload spec, and ResourceClaim outputs
+2. **String Traversal**: Scan all string fields in composed values for `${...}` patterns
+3. **Plan Emission Control**: If unresolved placeholders found, skip WorkloadPlan creation
+4. **Status Reporting**: Set `RuntimeReady=False` with `Reason=ProjectionError` and neutral message
+5. **Automatic Retry**: Requeue for reconciliation when ResourceClaim outputs become available
+
+**Error Message Format**: `"One or more required outputs are not resolved."` (single sentence, neutral wording, ends with period)
+
+**Event Logging**: Record single, neutral event per unresolved state (avoid log spam during waiting periods)
+
 ---
 
 ## Configuration Examples

--- a/docs/spec/rbac.md
+++ b/docs/spec/rbac.md
@@ -128,7 +128,7 @@ The Orchestrator **must be able to read its configuration** (e.g., a ConfigMap i
 
 **Security Constraints:**
 - **Cannot** create or modify `Workload` resources (prevents unauthorized workload injection)
-- **Cannot** write to `ResourceClaim.status` (prevents binding state corruption)
+- **Cannot** write to `ResourceClaim.status` (prevents claim state corruption)
 - **Must** verify OwnerReference before creating internal resources
 - **Should** implement leader election for high availability
 
@@ -181,7 +181,7 @@ rules:
 
 **Security Constraints:**
 - May **read** `Workload` metadata if needed (read-only); must not bypass orchestration
-- **Cannot** modify `ResourceClaim` resources (prevents binding manipulation)
+- **Cannot** modify `ResourceClaim` resources (prevents claim manipulation)
 - **Must** validate OwnerReference on `WorkloadPlan` before processing
 - **Should** implement resource quotas and limits for platform resources
 
@@ -191,7 +191,7 @@ Provisioner Controllers manage specific resource types and provide standardized 
 
 **Core Responsibilities:**
 - Claim and bind `ResourceClaim` resources of supported types
-- **Exclusive writer** of `ResourceClaim.status` for owned bindings
+- **Exclusive writer** of `ResourceClaim.status` for owned claims
 - Provision underlying resources (databases, message queues, storage, etc.)
 - Populate standardized outputs for consumption by Runtime Controllers
 

--- a/docs/spec/validation.md
+++ b/docs/spec/validation.md
@@ -94,6 +94,10 @@ spec.containers.all(container,
 - **Placeholders resolution order**: **Provision → Projection(IR) → Render** (`${resources.*}` is resolved by provisioner outputs)
 - **Values precedence**: **`defaults ⊕ normalize(Workload) ⊕ outputs`** (right-hand wins)
 
+### Placeholder Detection Boundary
+
+**NOT handled by CEL/Admission**: Deep traversal of arbitrary nested values for unresolved `${...}` placeholders is **not performed at the CRD level**. This validation occurs within the Orchestrator before `WorkloadPlan` emission. If unresolved placeholders remain, the Orchestrator skips Plan creation and sets `RuntimeReady=False` with `Reason=ProjectionError` on `Workload.status`.
+
 **CEL examples (illustrative)**
 - Exactly-one for files:
 ```cel
@@ -303,11 +307,12 @@ spec:
 
 **DO NOT ENFORCE:**
 - Organization-specific naming patterns
-- Registry or image restrictions  
+- Registry or image restrictions
 - Resource quotas or limits
 - Team or environment-specific policies
 - Cost or approval workflows
 - Security scanning requirements
+- Unresolved `${...}` placeholder detection (handled by Orchestrator pre-emission check)
 
 ### Platform Responsibilities (Policy Level)
 


### PR DESCRIPTION
- Update placeholder detection approach: Orchestrator performs pre-emission validation instead of CEL/admission to detect unresolved ${...} patterns
- Add ProjectionError reason when placeholders prevent WorkloadPlan emission
- Update terminology: binding summaries → claim summaries, bindings → claims
- Add ADR-0006 documenting terminology and placeholder handling pivot
- Keep WorkloadPlan internal and minimal as projection contract only
- Maintain validation boundaries: OpenAPI+CEL for spec invariants, VAP/OPA/Kyverno for org policies

No YAML or code changes in this commit (docs-only).