### PR TITLE
feat(orchestrator): gate plan emission on unresolved placeholders

### DIFF
--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -59,6 +59,7 @@ const (
 	MessageAllClaimsReady            = "All resource claims are ready"
 	MessageClaimsFailed              = "One or more resource claims have failed"
 	MessageNoClaimsFound             = "No resource claims found"
+	MessageProjectionError           = "One or more required outputs are not resolved."
 )
 
 // SetCondition updates a condition in the conditions slice
@@ -109,6 +110,33 @@ func GetCondition(conditions []metav1.Condition, conditionType string) *metav1.C
 		}
 	}
 	return nil
+}
+
+// ForProjectionError creates conditions for projection error state
+func ForProjectionError(message string) []ConditionUpdate {
+	return []ConditionUpdate{
+		{
+			Type:    ConditionRuntimeReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonProjectionError,
+			Message: message,
+		},
+	}
+}
+
+// ConditionUpdate represents a condition update operation
+type ConditionUpdate struct {
+	Type    string
+	Status  metav1.ConditionStatus
+	Reason  string
+	Message string
+}
+
+// ApplyConditionUpdates applies multiple condition updates to a conditions slice
+func ApplyConditionUpdates(conditions *[]metav1.Condition, updates []ConditionUpdate) {
+	for _, update := range updates {
+		SetCondition(conditions, update.Type, update.Status, update.Reason, update.Message)
+	}
 }
 
 // ComputeReadyCondition determines the Ready condition based on other conditions

--- a/internal/projection/placeholder.go
+++ b/internal/projection/placeholder.go
@@ -1,0 +1,44 @@
+package projection
+
+import (
+	"encoding/json"
+	"regexp"
+)
+
+var placeholderRe = regexp.MustCompile(`\$\{[^}]+\}`)
+
+// HasUnresolvedPlaceholders parses JSON and returns:
+// - true,nil  : at least one "${...}" found
+// - false,nil : no placeholders
+// - true,err  : JSON parse error (fail-safe => treat as unresolved)
+func HasUnresolvedPlaceholders(raw []byte) (bool, error) {
+	var v any
+	if len(raw) == 0 {
+		return false, nil
+	}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		// fail-safe: parsing error is treated as unresolved (block plan emission)
+		return true, err
+	}
+	return scan(v), nil
+}
+
+func scan(v any) bool {
+	switch x := v.(type) {
+	case string:
+		return placeholderRe.MatchString(x)
+	case []any:
+		for _, it := range x {
+			if scan(it) {
+				return true
+			}
+		}
+	case map[string]any:
+		for _, it := range x {
+			if scan(it) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/projection/placeholder_test.go
+++ b/internal/projection/placeholder_test.go
@@ -1,0 +1,30 @@
+package projection
+
+import "testing"
+
+func TestHasUnresolvedPlaceholders(t *testing.T) {
+	tcs := []struct {
+		name    string
+		json    string
+		wantHas bool
+		wantErr bool
+	}{
+		{"empty", ``, false, false},
+		{"noPlaceholders", `{"a":"b","n":123,"arr":[1,2,3]}`, false, false},
+		{"simple", `{"x":"${FOO}"}`, true, false},
+		{"nested", `{"a":{"b":["ok", {"c":"v${BAR}"}]}}`, true, false},
+		{"array", `["ok","${X}","y"]`, true, false},
+		{"invalidJSON", `{"x":`, true, true}, // fail-safe: treat as unresolved
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			has, err := HasUnresolvedPlaceholders([]byte(tc.json))
+			if has != tc.wantHas {
+				t.Fatalf("has=%v, want=%v", has, tc.wantHas)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add placeholder detection to prevent WorkloadPlan creation when unresolved placeholders exist in the workload projection. Sets RuntimeReady=False with ProjectionError reason to provide clear feedback to users.

- Add HasUnresolvedPlaceholders utility in internal/projection
- Add MessageProjectionError constant and helper functions
- Check for placeholders in UpsertWorkloadPlan before plan creation
- Update PlanManager error handling for unresolved placeholders