### PR TITLE
runtime: publish canonical URL via WorkloadExposure.status (minimal)

### DIFF
--- a/runtimes/kubernetes/cmd/main.go
+++ b/runtimes/kubernetes/cmd/main.go
@@ -175,12 +175,22 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	setupLog.Info("Setting up Kubernetes Runtime Controller")
-	if err := (&runtimectrl.KubernetesRuntimeReconciler{
+	runtimeController := &runtimectrl.KubernetesRuntimeReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("kubernetes-runtime-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}
+
+	// Setup WorkloadPlan controller
+	if err := runtimeController.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubernetesRuntime")
+		os.Exit(1)
+	}
+
+	// Setup WorkloadExposure controller
+	setupLog.Info("Setting up WorkloadExposure Controller")
+	if err := runtimeController.SetupWorkloadExposureWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "WorkloadExposure")
 		os.Exit(1)
 	}
 

--- a/runtimes/kubernetes/internal/controller/kubernetes_controller.go
+++ b/runtimes/kubernetes/internal/controller/kubernetes_controller.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -38,11 +41,34 @@ type KubernetesRuntimeReconciler struct {
 func (r *KubernetesRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// 1. Get WorkloadPlan
+	// First, try to get WorkloadPlan
 	plan := &scorev1b1.WorkloadPlan{}
-	if err := r.Get(ctx, req.NamespacedName, plan); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+	if err := r.Get(ctx, req.NamespacedName, plan); err == nil {
+		// This is a WorkloadPlan reconciliation
+		return r.reconcileWorkloadPlan(ctx, req, plan)
+	} else if !errors.IsNotFound(err) {
+		return ctrl.Result{}, err
 	}
+
+	// Then, try to get WorkloadExposure
+	we := &scorev1b1.WorkloadExposure{}
+	if err := r.Get(ctx, req.NamespacedName, we); err == nil {
+		// This is a WorkloadExposure reconciliation
+		return r.ReconcileWorkloadExposure(ctx, req)
+	} else if !errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	// Neither found, resource was deleted or doesn't exist
+	logger.V(1).Info("Resource not found", "request", req.NamespacedName)
+	return ctrl.Result{}, nil
+}
+
+// reconcileWorkloadPlan handles WorkloadPlan changes and materializes Kubernetes resources
+// RBAC permissions are managed manually in deployments/kubernetes-runtime/rbac.yaml
+// to avoid contaminating the main Orchestrator RBAC configuration
+func (r *KubernetesRuntimeReconciler) reconcileWorkloadPlan(ctx context.Context, req ctrl.Request, plan *scorev1b1.WorkloadPlan) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
 
 	// Skip non-kubernetes runtime classes
 	if plan.Spec.RuntimeClass != "kubernetes" {
@@ -89,6 +115,250 @@ func (r *KubernetesRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	logger.Info("Successfully reconciled WorkloadPlan", "workloadPlan", req.NamespacedName)
 	return ctrl.Result{}, nil
+}
+
+// ReconcileWorkloadExposure handles WorkloadExposure resources and publishes canonical URLs
+func (r *KubernetesRuntimeReconciler) ReconcileWorkloadExposure(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// 1. Get WorkloadExposure
+	we := &scorev1b1.WorkloadExposure{}
+	if err := r.Get(ctx, req.NamespacedName, we); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Skip non-kubernetes runtime classes
+	if we.Spec.RuntimeClass != "kubernetes" {
+		logger.V(1).Info("Skipping WorkloadExposure with non-kubernetes runtime class",
+			"runtimeClass", we.Spec.RuntimeClass)
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("Reconciling WorkloadExposure for Kubernetes runtime",
+		"workloadExposure", req.NamespacedName,
+		"runtimeClass", we.Spec.RuntimeClass)
+
+	// 2. Get referenced Workload
+	workload := &scorev1b1.Workload{}
+	workloadKey := types.NamespacedName{
+		Name: we.Spec.WorkloadRef.Name,
+	}
+
+	// Set namespace - use explicit namespace if provided, otherwise use same as WorkloadExposure
+	if we.Spec.WorkloadRef.Namespace != nil && *we.Spec.WorkloadRef.Namespace != "" {
+		workloadKey.Namespace = *we.Spec.WorkloadRef.Namespace
+	} else {
+		workloadKey.Namespace = we.Namespace
+	}
+
+	if err := r.Get(ctx, workloadKey, workload); err != nil {
+		logger.Error(err, "Failed to get referenced Workload")
+		r.Recorder.Event(we, corev1.EventTypeWarning, "WorkloadNotFound", err.Error())
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+
+	// Validate UID if specified (strong identity check)
+	if we.Spec.WorkloadRef.UID != "" && string(workload.UID) != we.Spec.WorkloadRef.UID {
+		logger.V(1).Info("Workload UID mismatch, skipping (may be recreated)",
+			"expectedUID", we.Spec.WorkloadRef.UID,
+			"actualUID", workload.UID)
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+
+	// 3. Generation guard - skip if observedWorkloadGeneration is behind
+	if we.Spec.ObservedWorkloadGeneration < workload.Generation {
+		logger.V(1).Info("Skipping WorkloadExposure with outdated generation",
+			"observedGeneration", we.Spec.ObservedWorkloadGeneration,
+			"currentGeneration", workload.Generation)
+		return ctrl.Result{RequeueAfter: time.Second * 30}, nil
+	}
+
+	// 4. Generate canonical URL from confirmed primary information (Ingress/LB only)
+	exposureURL, err := r.generateCanonicalURL(ctx, workload, we.Namespace)
+	if err != nil {
+		logger.Error(err, "Failed to generate canonical URL")
+		r.Recorder.Event(we, corev1.EventTypeWarning, "URLGenerationFailed", err.Error())
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+
+	if exposureURL == "" || !r.isValidURL(exposureURL) {
+		logger.V(1).Info("No valid URL available yet, exposure may be pending", "url", exposureURL)
+		return ctrl.Result{RequeueAfter: time.Second * 30}, nil
+	}
+
+	// 5. Build desired exposures
+	exposureType := "ingress"
+	if strings.Contains(exposureURL, "svc.cluster.local") {
+		exposureType = "service"
+	} else if strings.Contains(exposureURL, ":") && !strings.Contains(exposureURL, "://") {
+		exposureType = "loadbalancer"
+	}
+
+	desired := []scorev1b1.ExposureEntry{{
+		URL:   exposureURL,
+		Ready: true,
+		Type:  exposureType,
+	}}
+
+	// 6. Check if update is needed (avoid flapping) using DeepEqual
+	if reflect.DeepEqual(we.Status.Exposures, desired) {
+		logger.V(1).Info("Exposures unchanged, no update needed", "url", exposureURL)
+		return ctrl.Result{}, nil
+	}
+
+	// 7. Update status
+	we.Status.Exposures = desired
+	if err := r.Status().Update(ctx, we); err != nil {
+		logger.Error(err, "Failed to update WorkloadExposure status")
+		return ctrl.Result{RequeueAfter: time.Minute}, err
+	}
+
+	logger.Info("Successfully updated WorkloadExposure status", "url", exposureURL, "type", exposureType)
+	r.Recorder.Eventf(we, corev1.EventTypeNormal, "ExposurePublished",
+		"Published %s exposure URL: %s", exposureType, exposureURL)
+
+	return ctrl.Result{}, nil
+}
+
+// generateCanonicalURL publishes canonical URL from materialized exposure (confirmed primary info only)
+// Only publishes URLs from confirmed sources: Ingress with hostnames or LoadBalancer with external IPs/hostnames.
+// Does NOT publish ClusterIP, NodePort, or other unconfirmed endpoints.
+func (r *KubernetesRuntimeReconciler) generateCanonicalURL(ctx context.Context, workload *scorev1b1.Workload, namespace string) (string, error) {
+	// Skip if no service is defined
+	if workload.Spec.Service == nil || len(workload.Spec.Service.Ports) == 0 {
+		return "", nil
+	}
+
+	workloadName := workload.Name
+
+	// Priority 1: Check for Ingress with confirmed hostnames
+	if ingressURL, err := r.getURLFromIngress(ctx, workloadName, namespace); err != nil {
+		return "", fmt.Errorf("failed to check ingress: %w", err)
+	} else if ingressURL != "" {
+		return ingressURL, nil
+	}
+
+	// Priority 2: Check for LoadBalancer Service with external IPs/hostnames
+	if lbURL, err := r.getURLFromLoadBalancer(ctx, workloadName, namespace); err != nil {
+		return "", fmt.Errorf("failed to check load balancer: %w", err)
+	} else if lbURL != "" {
+		return lbURL, nil
+	}
+
+	// Priority 3: For now, do not publish ClusterIP/NodePort URLs
+	// as they are not externally accessible or stable
+	// TODO: Add NodePort support when external access is confirmed
+	return "", nil
+}
+
+// getURLFromIngress checks for Ingress resources with confirmed hostnames and returns the first available URL
+func (r *KubernetesRuntimeReconciler) getURLFromIngress(ctx context.Context, workloadName, namespace string) (string, error) {
+	// List Ingresses that might be associated with this workload
+	var ingressList networkingv1.IngressList
+	if err := r.List(ctx, &ingressList, client.InNamespace(namespace)); err != nil {
+		return "", err
+	}
+
+	for _, ingress := range ingressList.Items {
+		// Check if this Ingress references our Service
+		for _, rule := range ingress.Spec.Rules {
+			if rule.Host == "" {
+				continue // Skip rules without hostnames
+			}
+
+			// Check if this rule has paths pointing to our service
+			if rule.HTTP != nil {
+				for _, path := range rule.HTTP.Paths {
+					if path.Backend.Service != nil && path.Backend.Service.Name == workloadName {
+						// Found a matching Ingress rule with hostname
+						scheme := "https"
+						if len(ingress.Spec.TLS) == 0 {
+							scheme = "http"
+						}
+						exposureURL := fmt.Sprintf("%s://%s", scheme, rule.Host)
+						if path.Path != "" && path.Path != "/" {
+							exposureURL += path.Path
+						}
+						return exposureURL, nil
+					}
+				}
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// getURLFromLoadBalancer checks for LoadBalancer Service with external IPs/hostnames
+func (r *KubernetesRuntimeReconciler) getURLFromLoadBalancer(ctx context.Context, workloadName, namespace string) (string, error) {
+	service := &corev1.Service{}
+	serviceKey := types.NamespacedName{
+		Name:      workloadName,
+		Namespace: namespace,
+	}
+
+	if err := r.Get(ctx, serviceKey, service); err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	// Only handle LoadBalancer type services
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return "", nil
+	}
+
+	// Check if LoadBalancer has external IP or hostname
+	if len(service.Status.LoadBalancer.Ingress) == 0 {
+		return "", nil // LoadBalancer not ready yet
+	}
+
+	// Use first available ingress point
+	ingress := service.Status.LoadBalancer.Ingress[0]
+	var host string
+	if ingress.Hostname != "" {
+		host = ingress.Hostname
+	} else if ingress.IP != "" {
+		host = ingress.IP
+	} else {
+		return "", nil // No usable address
+	}
+
+	// Get the first port for URL construction
+	if len(service.Spec.Ports) == 0 {
+		return "", nil
+	}
+	port := service.Spec.Ports[0].Port
+
+	// Construct URL (assume HTTP for now, could be enhanced to detect HTTPS)
+	exposureURL := fmt.Sprintf("http://%s:%d", host, port)
+	return exposureURL, nil
+}
+
+// isValidURL validates if the given string is a valid HTTP/HTTPS URL
+func (r *KubernetesRuntimeReconciler) isValidURL(urlStr string) bool {
+	if urlStr == "" {
+		return false
+	}
+
+	// Parse URL and validate structure
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+
+	// Validate scheme is HTTP or HTTPS
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+
+	// Validate host is not empty
+	if u.Host == "" {
+		return false
+	}
+
+	return true
 }
 
 // getWorkload retrieves the referenced Workload from WorkloadPlan
@@ -575,4 +845,74 @@ func (r *KubernetesRuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &scorev1b1.WorkloadPlan{}),
 		).
 		Complete(r)
+}
+
+// SetupWorkloadExposureWithManager sets up the WorkloadExposure controller with the Manager
+func (r *KubernetesRuntimeReconciler) SetupWorkloadExposureWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&scorev1b1.WorkloadExposure{}).
+		Watches(
+			&scorev1b1.Workload{},
+			handler.EnqueueRequestsFromMapFunc(r.findWorkloadExposuresForWorkload),
+		).
+		Watches(
+			&corev1.Service{},
+			handler.EnqueueRequestsFromMapFunc(r.findWorkloadExposuresForService),
+		).
+		Named("workloadexposure").
+		Complete(r)
+}
+
+// findWorkloadExposuresForWorkload finds WorkloadExposures that reference the given Workload
+func (r *KubernetesRuntimeReconciler) findWorkloadExposuresForWorkload(ctx context.Context, obj client.Object) []ctrl.Request {
+	workload := obj.(*scorev1b1.Workload)
+
+	// List all WorkloadExposures in the same namespace
+	var exposures scorev1b1.WorkloadExposureList
+	if err := r.List(ctx, &exposures, client.InNamespace(workload.Namespace)); err != nil {
+		return nil
+	}
+
+	var requests []ctrl.Request
+	for _, exposure := range exposures.Items {
+		// Check if this exposure references the workload
+		if exposure.Spec.WorkloadRef.Name == workload.Name {
+			// Check namespace match (nil means same namespace as exposure)
+			exposureNamespace := workload.Namespace
+			if exposure.Spec.WorkloadRef.Namespace != nil && *exposure.Spec.WorkloadRef.Namespace != "" {
+				exposureNamespace = *exposure.Spec.WorkloadRef.Namespace
+			}
+
+			if exposureNamespace == workload.Namespace {
+				requests = append(requests, ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      exposure.Name,
+						Namespace: exposure.Namespace,
+					},
+				})
+			}
+		}
+	}
+
+	return requests
+}
+
+// findWorkloadExposuresForService finds WorkloadExposures that might be affected by Service changes
+func (r *KubernetesRuntimeReconciler) findWorkloadExposuresForService(ctx context.Context, obj client.Object) []ctrl.Request {
+	service := obj.(*corev1.Service)
+
+	// Find the corresponding Workload (Service name should match Workload name)
+	workload := &scorev1b1.Workload{}
+	workloadKey := types.NamespacedName{
+		Name:      service.Name,
+		Namespace: service.Namespace,
+	}
+
+	if err := r.Get(ctx, workloadKey, workload); err != nil {
+		// No corresponding workload found
+		return nil
+	}
+
+	// Use the workload mapping function
+	return r.findWorkloadExposuresForWorkload(ctx, workload)
 }

--- a/runtimes/kubernetes/manifests/rbac.yaml
+++ b/runtimes/kubernetes/manifests/rbac.yaml
@@ -52,6 +52,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - score.dev
+  resources:
+  - workloadexposures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - score.dev
+  resources:
+  - workloadexposures/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -74,6 +90,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
- Watch WorkloadExposure and publish exposures[0].url from the runtime's materialized exposure (Ingress/LB/Gateway).
- Validate URI, guard by observedWorkloadGeneration, avoid flapping (no-op on same URL). Status is written only by Runtime, spec remains orchestrator-owned.
- Scope/schemeHint/reachable are left for follow-ups; start with URL only.

Refs: ADR-0007, #75