### PR TITLE
Fix empty resource claims handling

### DIFF
--- a/internal/controller/managers/claim_manager.go
+++ b/internal/controller/managers/claim_manager.go
@@ -216,9 +216,9 @@ func (cm *ClaimManager) getResourceClaimsWithoutIndex(ctx context.Context, workl
 func (cm *ClaimManager) AggregateStatus(claims []scorev1b1.ResourceClaim) status.ClaimAggregation {
 	if len(claims) == 0 {
 		return status.ClaimAggregation{
-			Ready:   false,
-			Reason:  conditions.ReasonClaimPending,
-			Message: conditions.MessageNoClaimsFound,
+			Ready:   true,
+			Reason:  conditions.ReasonSucceeded,
+			Message: "No resource dependencies",
 			Claims:  []scorev1b1.ClaimSummary{},
 		}
 	}

--- a/internal/controller/managers/claim_manager_test.go
+++ b/internal/controller/managers/claim_manager_test.go
@@ -160,11 +160,11 @@ var _ = Describe("ClaimManager", func() {
 	})
 
 	Describe("AggregateStatus", func() {
-		It("should return not ready when no claims", func() {
+		It("should return ready when no claims exist", func() {
 			agg := claimManager.AggregateStatus([]scorev1b1.ResourceClaim{})
-			Expect(agg.Ready).To(BeFalse())
-			Expect(agg.Reason).To(Equal(conditions.ReasonClaimPending))
-			Expect(agg.Message).To(Equal(conditions.MessageNoClaimsFound))
+			Expect(agg.Ready).To(BeTrue())
+			Expect(agg.Reason).To(Equal(conditions.ReasonSucceeded))
+			Expect(agg.Message).To(Equal("No resource dependencies"))
 			Expect(agg.Claims).To(BeEmpty())
 		})
 

--- a/internal/status/aggregate.go
+++ b/internal/status/aggregate.go
@@ -35,9 +35,9 @@ type ClaimAggregation struct {
 func AggregateClaimStatuses(claims []scorev1b1.ResourceClaim) ClaimAggregation {
 	if len(claims) == 0 {
 		return ClaimAggregation{
-			Ready:   false,
-			Reason:  conditions.ReasonClaimPending,
-			Message: conditions.MessageNoClaimsFound,
+			Ready:   true,
+			Reason:  conditions.ReasonSucceeded,
+			Message: "No resource dependencies",
 			Claims:  []scorev1b1.ClaimSummary{},
 		}
 	}


### PR DESCRIPTION
Change claim aggregation logic to return Ready=true when no resource claims exist. Workloads without dependencies should be considered ready rather than pending, allowing WorkloadPlan creation to proceed.

Updates both status.AggregateClaimStatuses and ClaimManager.AggregateStatus to return success condition with appropriate message.