### PR TITLE
docs: add ADR-0008 for development-grade provisioning strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Score defines a portable way to describe applications. This project provides a s
 - Internal contracts for platform use: `ResourceClaim`, `WorkloadPlan`
 - Status is abstract and user-centric (a single `endpoint`, abstract `conditions`, claim summaries)
 - Validation boundary: **CRD OpenAPI + CEL** for spec invariants; org policy via **VAP/OPA/Kyverno**
+- **Development-grade provisioning** for databases and services (aligned with score-k8s approach)
 
 ## What happens when dependencies are not ready?
 When required outputs from `ResourceClaim` resolvers contain unresolved `${...}` placeholders, the Orchestrator detects this before emitting a `WorkloadPlan`. Instead of passing unresolved values to the runtime, it sets `Workload.status` with `RuntimeReady=False` and `Reason=ProjectionError`. Once resolver outputs are complete, the Orchestrator emits the Plan and the Workload converges to Ready.

--- a/docs/ADR/ADR-0008-development-provisioning.md
+++ b/docs/ADR/ADR-0008-development-provisioning.md
@@ -1,0 +1,105 @@
+# ADR-0008: Development-Grade Resource Provisioning Strategy
+
+**Status**: Accepted
+**Date**: 2025-09-27
+
+## Context
+
+During the implementation of the Getting Started guide (Issue #91), we discovered that the current PostgreSQL provisioner only creates a Secret with mock connection details but doesn't provision an actual PostgreSQL instance. This causes Score sample applications to fail with CrashLoopBackOff because they cannot connect to a database.
+
+Investigation of the official Score implementation (`score-k8s`) revealed that it provides **complete development-grade provisioning** for resources like PostgreSQL, Redis, MySQL, etc., creating actual StatefulSets, Services, and persistent storage alongside credential Secrets.
+
+Key findings from score-k8s analysis:
+1. **Template-based provisioning** creates complete database instances (StatefulSet + Service + Secret + PVC)
+2. **Development-first approach** with immediate functionality out-of-the-box
+3. **Production replacement expectation** - users are expected to provide custom provisioners for production environments
+4. **Clear documentation** about development vs. production use cases
+
+The current approach in this project of providing only Secret-based mock provisioning creates a poor Getting Started experience and diverges from user expectations set by the official Score tooling.
+
+## Decision
+
+We will adopt a **development-grade provisioning strategy** aligned with score-k8s, where provisioners create functional resource instances suitable for development and demonstration purposes.
+
+### Core Principles
+
+1. **Development-First Experience**: Provisioners should create working resource instances that enable immediate functionality testing
+2. **Production Replacement Path**: Clear documentation and architecture that allows production provisioners to replace development ones
+3. **Score Ecosystem Alignment**: Match the approach and user expectations established by score-k8s
+4. **Graduated Sophistication**: Start with development-grade implementations, evolve toward production-ready patterns
+
+### Implementation Strategy
+
+For resource types like `postgres`, `redis`, `mysql`, etc., provisioners will create:
+
+1. **StatefulSet**: Running the actual database/service container
+2. **Service**: ClusterIP service for internal connectivity
+3. **Secret**: Generated credentials and connection details
+4. **PersistentVolumeClaim**: Basic storage for data persistence (development-grade)
+
+Example PostgreSQL provisioning will include:
+- StatefulSet with `postgres:alpine` container
+- ClusterIP Service exposing port 5432
+- Secret with generated username/password
+- PVC with modest storage allocation (1Gi)
+- Owner references for proper cleanup
+
+### Development vs. Production Positioning
+
+- **Development Use**: Complete, working instances with reasonable defaults
+- **Production Use**: Template for replacement with operator-based or cloud-managed resources
+- **Documentation**: Clear guidance on production deployment patterns
+- **Configuration**: Provision for environment-specific provisioner selection
+
+## Consequences
+
+### Positive
+
+1. **Improved Getting Started Experience**: Users can immediately test complete workload functionality
+2. **Score Ecosystem Consistency**: Aligns with official Score tooling expectations
+3. **Reference Implementation Value**: Demonstrates complete Score capability
+4. **Development Velocity**: Faster iteration cycles with working dependencies
+
+### Negative
+
+1. **Increased Complexity**: Provisioners become more sophisticated than simple Secret creation
+2. **Resource Overhead**: Development clusters will run additional database instances
+3. **Security Considerations**: Default configurations may not meet production security standards
+4. **Maintenance Burden**: More complex provisioners require more maintenance
+
+### Mitigation
+
+1. **Clear Documentation**: Emphasize development-grade nature and production replacement paths
+2. **Resource Limits**: Apply reasonable resource constraints to prevent cluster resource exhaustion
+3. **Security Defaults**: Use basic security practices suitable for development environments
+4. **Modular Design**: Ensure provisioners can be easily replaced or extended
+
+## Alternatives Considered
+
+1. **Mock-Only Provisioning (Current Approach)**
+   - Rejected: Poor user experience, diverges from Score ecosystem
+
+2. **External Dependency Requirements**
+   - Rejected: Increases Getting Started complexity, requires additional setup
+
+3. **Optional Development Mode**
+   - Considered but rejected: Adds configuration complexity without clear benefit
+
+4. **Helm-Based Provisioning**
+   - Deferred: Requires Helm dependency, can be added later as alternative strategy
+
+## References
+
+- Issue #91: Implement actual PostgreSQL provisioning for Getting Started guide
+- score-k8s default provisioners: https://github.com/score-spec/score-k8s/blob/main/internal/provisioners/default/zz-default.provisioners.yaml
+- ADR-0005: Unified Provisioner Controller Design
+- Getting Started guide requirements and user expectations
+
+## Implementation Plan
+
+1. **Phase 1**: Update PostgreSQL provisioner to create StatefulSet + Service + Secret
+2. **Phase 2**: Update documentation to reflect development-grade positioning
+3. **Phase 3**: Create production replacement guidance and examples
+4. **Phase 4**: Apply same pattern to other resource types (Redis, MySQL, etc.)
+
+This approach balances immediate usability with long-term architectural flexibility, positioning the project as both a useful reference implementation and a foundation for production deployment patterns.

--- a/docs/spec/control-plane.md
+++ b/docs/spec/control-plane.md
@@ -22,8 +22,8 @@ It complements:
   - Processes `ResourceClaim` deletion according to `DeprovisionPolicy` before removing Workload finalizer
 
 ### Provisioner (PF/vendor)
-- **Watches:** `ResourceClaim` for its `spec.type`; own `Secret/ConfigMap`; external service APIs as needed
-- **Creates/updates (objects):** `Secret/ConfigMap` with credentials/config (same namespace)
+- **Watches:** `ResourceClaim` for its `spec.type`; own resources; external service APIs as needed
+- **Creates/updates (objects):** `Secret/ConfigMap` with credentials/config; for development-grade provisioning, may also create `StatefulSet/Deployment`, `Service`, `PVC` (same namespace)
 - **Updates (status):** `ResourceClaim.status` (`phase`, `reason`, `message`, `outputs`, timestamps)
 - **Produces image outputs (when applicable):** Provisioners for `image|build|buildpack` types publish an OCI reference as `ResourceClaim.status.outputs.image`.
 - **Plan linkage:** The Orchestrator emits a `WorkloadPlan` projection that binds that output into the final container image, e.g.:
@@ -62,6 +62,8 @@ It complements:
 | `WorkloadPlan` (internal)   | Runtime, Orchestrator, WorkloadExposureRegistrar | **Orchestrator** (single writer) | —                      | Same name as Workload; OwnerRef = Workload |
 | `WorkloadExposure` (internal) | ExposureMirror, WorkloadExposureRegistrar, Runtime | **WorkloadExposureRegistrar** | **Runtime Controllers**   | Same name as Workload; OwnerRef = Workload; hidden from users |
 | `Secret/ConfigMap` (outputs) | Runtime (read), Orchestrator (not required) | **Provisioner**              | —                         | Same namespace; hidden from users |
+| `StatefulSet/Deployment` (dev) | —                                       | **Provisioner** (development-grade) | —                         | Development-grade provisioning only; same namespace |
+| `Service` (dev)             | —                                       | **Provisioner** (development-grade) | —                         | Development-grade provisioning only; same namespace |
 
 ## Claim ↔ Plan linkage (how they meet)
 - **Key-based mapping:** `WorkloadPlan.spec.projection` refers to dependencies by `claimKey` (the key in `Workload.spec.resources`).  


### PR DESCRIPTION
Add ADR-0008 to establish development-grade resource provisioning aligned with score-k8s approach. This enables functional Getting Started experiences while maintaining production replacement paths.

Changes:
- New ADR-0008 documenting development provisioning strategy
- Update control-plane.md to reflect provisioner responsibilities
- Update README.md to mention development-grade provisioning

Relates to Issue #91 for PostgreSQL provisioning implementation.