### PR TITLE
fix: resolve placeholders by reading Secret data instead of hardcoded…

### DIFF
--- a/docs/examples/node-postgres/workload.yaml
+++ b/docs/examples/node-postgres/workload.yaml
@@ -8,10 +8,10 @@ spec:
     app:
       image: ghcr.io/score-spec/sample-app-gif:main
       variables:
-        DATABASE_URL: "postgresql://${resources.db.username}:${resources.db.password}@${resources.db.host}:${resources.db.port}/${resources.db.name}"
+        DATABASE_URL: "postgresql://${resources.db.username}:${resources.db.password}@${resources.db.host}:${resources.db.port}/${resources.db.database}"
         DB_HOST: "${resources.db.host}"
         DB_PORT: "${resources.db.port}"
-        DB_NAME: "${resources.db.name}"
+        DB_NAME: "${resources.db.database}"
         DB_USER: "${resources.db.username}"
         DB_PASSWORD: "${resources.db.password}"
   service:

--- a/internal/reconcile/plan.go
+++ b/internal/reconcile/plan.go
@@ -53,7 +53,7 @@ func UpsertWorkloadPlan(ctx context.Context, c client.Client, workload *scorev1b
 	}
 
 	// Resolve all placeholders to create final values
-	resolvedValues, err := resolveAllPlaceholders(workload, claims)
+	resolvedValues, err := resolveAllPlaceholders(ctx, c, workload, claims)
 	if err != nil {
 		return fmt.Errorf("failed to resolve placeholders: %w", err)
 	}

--- a/internal/reconcile/resolver_test.go
+++ b/internal/reconcile/resolver_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package reconcile
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	scorev1b1 "github.com/cappyzawa/score-orchestrator/api/v1b1"
 )
@@ -88,7 +90,11 @@ func TestResolveAllPlaceholders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolvedValues, err := resolveAllPlaceholders(tt.workload, tt.claims)
+			// Create a fake client for testing
+			fakeClient := fake.NewClientBuilder().Build()
+			ctx := context.TODO()
+
+			resolvedValues, err := resolveAllPlaceholders(ctx, fakeClient, tt.workload, tt.claims)
 
 			if tt.expectError {
 				if err == nil {


### PR DESCRIPTION
… values

Replace hardcoded dummy values in buildResolvedOutputsMap with actual Secret data retrieval. Update placeholder references in node-postgres example from ${resources.db.name} to ${resources.db.database} to match PostgreSQL provisioner output keys.

Changes:
- Add context and client parameters to buildResolvedOutputsMap
- Read Secret data using Kubernetes client instead of dummy values
- Update resolveAllPlaceholders function signature and calls
- Fix placeholder keys in workload.yaml example
- Update tests with fake client initialization