### PR TITLE
fix: resolve WorkloadPlan environment variable projection to Deployment

### DIFF
--- a/docs/examples/node-postgres/workload.yaml
+++ b/docs/examples/node-postgres/workload.yaml
@@ -8,12 +8,7 @@ spec:
     app:
       image: ghcr.io/score-spec/sample-app-gif:main
       variables:
-        DATABASE_URL: "postgresql://${resources.db.username}:${resources.db.password}@${resources.db.host}:${resources.db.port}/${resources.db.database}"
-        DB_HOST: "${resources.db.host}"
-        DB_PORT: "${resources.db.port}"
-        DB_NAME: "${resources.db.database}"
-        DB_USER: "${resources.db.username}"
-        DB_PASSWORD: "${resources.db.password}"
+        PG_CONNECTION_STRING: "postgresql://${resources.db.username}:${resources.db.password}@${resources.db.host}:${resources.db.port}/${resources.db.database}?sslmode=disable"
   service:
     ports:
       - port: 8080

--- a/runtimes/kubernetes/internal/controller/plan_controller.go
+++ b/runtimes/kubernetes/internal/controller/plan_controller.go
@@ -421,7 +421,7 @@ func (r *KubernetesRuntimePlanReconciler) buildService(plan *scorev1b1.WorkloadP
 func (r *KubernetesRuntimePlanReconciler) extractResolvedEnv(resolvedValues map[string]interface{}, containerName string) (map[string]string, error) {
 	result := make(map[string]string)
 
-	// Navigate to containers.<containerName>.variables
+	// Navigate to containers.<containerName>.env
 	containersRaw, exists := resolvedValues["containers"]
 	if !exists {
 		return result, nil
@@ -442,18 +442,18 @@ func (r *KubernetesRuntimePlanReconciler) extractResolvedEnv(resolvedValues map[
 		return result, fmt.Errorf("container %s is not a map", containerName)
 	}
 
-	variablesRaw, exists := containerMap["variables"]
+	envRaw, exists := containerMap["env"]
 	if !exists {
 		return result, nil
 	}
 
-	variablesMap, ok := variablesRaw.(map[string]interface{})
+	envMap, ok := envRaw.(map[string]interface{})
 	if !ok {
-		return result, fmt.Errorf("variables field for container %s is not a map", containerName)
+		return result, fmt.Errorf("env field for container %s is not a map", containerName)
 	}
 
 	// Convert all values to strings
-	for key, value := range variablesMap {
+	for key, value := range envMap {
 		if value == nil {
 			result[key] = ""
 		} else {


### PR DESCRIPTION
Environment variables from WorkloadPlan.resolvedValues were not being projected to Kubernetes Deployments because the runtime controller was incorrectly looking for 'variables' field instead of 'env' field.

This change updates extractResolvedEnv method to read from the correct 'containers.<name>.env' path in resolvedValues, enabling applications to receive necessary database connection details and other resource bindings.

Also simplifies node-postgres example to use only PG_CONNECTION_STRING variable that the sample application actually expects.